### PR TITLE
Removing warnings and fatals from php-lib/core.php

### DIFF
--- a/php-lib/core.php
+++ b/php-lib/core.php
@@ -22,7 +22,9 @@ abstract class :x:base {
   abstract public function setAttribute($attr, $val);
   abstract public function categoryOf($cat);
   abstract public function __toString();
-  abstract protected static function &__xhpAttributeDeclaration();
+  // PHP Strict Standards define that static function should not be declared
+  // abstract.
+  // abstract protected static function &__xhpAttributeDeclaration();
   abstract protected function &__xhpCategoryDeclaration();
   abstract protected function &__xhpChildrenDeclaration();
 
@@ -555,7 +557,11 @@ abstract class :x:primitive extends :x:composable-element {
     // Validate our children
     $this->__flushElementChildren();
     if (:x:base::$ENABLE_VALIDATION) {
-      $this->validateChildren();
+      try {
+        $this->validateChildren();
+      } catch (Exception $e) {
+        trigger_error($e->getMessage(), E_USER_ERROR);
+      }
     }
 
     // Render to string


### PR DESCRIPTION
Summary: PHP Strict Standards defines you can't declare static methods
abstract, so I just commented the __xhpAttributeDeclaration declaration.

__toString() should not throw "Exception"s, but trigger_error() is accepted, so I
just catch any Exception and trigger an E_USER_ERROR using the exception's
message.

There's almost no trade off as you probably don't handle exceptions converting
XHP objects to strings. If you have some kind of global error handling
you should make sure that the Exception handling and error handling should have
the same behavior.
