### PR TITLE
Invalid escaping in renderBaseAttrs

### DIFF
--- a/php-lib/html.php
+++ b/php-lib/html.php
@@ -65,7 +65,7 @@ abstract class :xhp:html-element extends :x:primitive {
     $buf = '<'.$this->tagName;
     foreach ($this->getAttributes() as $key => $val) {
       if ($val !== null && $val !== false) {
-        $buf .= ' ' . htmlspecialchars($key) . '="' . htmlspecialchars($val, true) . '"';
+        $buf .= ' ' . htmlspecialchars($key) . '="' . htmlspecialchars($val) . '"';
       }
     }
     return $buf;

--- a/tests/attr-quotes.phpt
+++ b/tests/attr-quotes.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Quotes in attribute
+--FILE--
+<?php
+class xhp_a {}
+$quote = '"';
+echo <a b={$quote}>c</a>;
+--EXPECT--
+<a b="&quot;">c</a>


### PR DESCRIPTION
Summary:
Second parameter of htmlspecialchars() is flags (int), not bool.
Value true is understood as 1 which means: quote single quotes, not double quotes

Test Plan:
New test
