### PR TITLE
Had issue building on gcc 4.7.0 on archlinux 

### DIFF
--- a/xhp/code_rope.cpp
+++ b/xhp/code_rope.cpp
@@ -14,8 +14,8 @@
   +----------------------------------------------------------------------+
 */
 
-#include "code_rope.hpp"
 using namespace std;
+#include "code_rope.hpp"
 
 code_rope::code_rope(const _rope_t str, const size_t no /* = 0 */, const size_t lf /* = 0 */) : str(str), lf(lf), no(no) {}
 


### PR DESCRIPTION
Simple change allowed the latest tag to build and complete all tests.
