### PR TITLE
Update INSTALL Brew instructions - XHP requires GCC to build

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,5 @@
 You can install XHP with Homebrew by first enabling some required
-repositories (https://github.com/josegonzalez/homebrew-php):
+repositories:
 
   brew tap homebrew/dupes
   brew tap homebrew/versions


### PR DESCRIPTION
Similar change to 8aa2d9fa6bf3a114e113ba5c554181279545fb2f - Force Homebrew build to use GCC rather than clang/llvm.
