### PR TITLE
Bugfix ?

### DIFF
--- a/xhp/fastpath.re
+++ b/xhp/fastpath.re
@@ -77,7 +77,7 @@ bool xhp_fastpath(const char* yy, const size_t len, const xhp_flags_t &flags) {
     }
     <PHP> '%>' {
       if (flags.asp_tags) {
-        state = PHP;
+        state = HTML;
       }
       continue;
     }


### PR DESCRIPTION
Shouldn't it be switch to HTML , when asp-tag + end %> ? it switches to PHP , but it's already PHP. 

compare to 
<PHP> '?>' {
      state = HTML;
      continue;
    }

where it switches to HTML in a similar condition. 

Maybe nobody tested asp-tags, seams to be broken in master.
