### PR TITLE
Mark all checker functions as callables

### DIFF
--- a/php-lib/core.php
+++ b/php-lib/core.php
@@ -638,10 +638,10 @@ abstract class :x:composable-element extends :x:base {
     if ($decl[0]) { // Key declaration
       if ($decl[0] == self::TYPE_STRING) {
         $type = 'string';
-        $func = 'is_string';
+        $func = fun('is_string');
       } else {
         $type = 'int';
-        $func = 'is_int';
+        $func = fun('is_int');
       }
       if (count($val) != count(array_filter(array_keys($val), $func))) {
         $bad = $type == 'string' ? 'int' : 'string';
@@ -656,27 +656,27 @@ abstract class :x:composable-element extends :x:base {
     switch ((int)$decl[1]) { // Value declaration
       case self::TYPE_STRING:
         $type = 'string';
-        $func = 'is_string';
+        $func = fun('is_string');
         break;
       case self::TYPE_BOOL:
         $type = 'bool';
-        $func = 'is_bool';
+        $func = fun('is_bool');
         break;
       case self::TYPE_NUMBER:
         $type = 'int';
-        $func = 'is_int';
+        $func = fun('is_int');
         break;
       case self::TYPE_FLOAT:
         $type = 'float';
-        $func = 'is_numeric';
+        $func = fun('is_numeric');
         break;
       case self::TYPE_CALLABLE:
         $type = 'callable';
-        $func = 'is_callable';
+        $func = fun('is_callable');
         return;
       case self::TYPE_ARRAY:
         $type = 'array';
-        $func = 'is_array';
+        $func = fun('is_array');
         break;
       case self::TYPE_OBJECT:
         $type = $decl[2];


### PR DESCRIPTION
`array_filter` is now typed in HHVM (happened some time in the last week), so we need to be passing in callables, not strings.

Fixes #78.
