### PR TITLE
Fix calling methods on new objects (e.g. (new foo())->doSomething()).

### DIFF
--- a/xhp/parser.y
+++ b/xhp/parser.y
@@ -1017,7 +1017,7 @@ expr_without_variable:
     $$ = $1;
   }
 | '(' new_expr ')' instance_call {
-    $$ = $1 + $2 + $4;
+    $$ = $1 + $2 + $3 + $4;
   }
 | T_CLONE expr {
     $$ = $1 + " " + $2;


### PR DESCRIPTION
Fixes #86.

tested on the code from that issue:

``` php
<?php

class :span {}

class foo {
    public function doSomething()
    {
    }
}

$bar = <span></span>;    // without this line, the code is all good

(new foo())->doSomething();    // error

var_dump('Finished.');
```

xhpize before:

``` php
<?php

class xhp_span{}

class foo{
public function doSomething()
{
}
}

$bar=new \xhp_span(array(), array(), __FILE__, 11);

(new foo()->doSomething();

var_dump('Finished.');
```

(note the missing close paren on the class instantiation).

xhpize after:

``` php
<?php

class xhp_span{}

class foo{
public function doSomething()
{
}
}

$bar=new \xhp_span(array(), array(), __FILE__, 11);

(new foo())->doSomething();

var_dump('Finished.');
```
