### PR TITLE
Implement ->: syntax for accessing XHP attributes.

### DIFF
--- a/tests/xhp-attribute-as-property.phpt
+++ b/tests/xhp-attribute-as-property.phpt
@@ -1,0 +1,26 @@
+--TEST--
+XHP ->: Syntax
+--FILE--
+<?php
+
+class :thing {
+  public function __construct($attributes) {
+    $this->attributes = $attributes;
+  }
+    
+  public function getAttribute($attr) {
+    return $this->attributes[$attr];
+  }
+}
+
+$y = <thing foo-bar="pass"/>;
+$y->prop = 'prop';
+$x = <thing xhp-child={$y} />;
+echo $y->:foo-bar."\n";  
+echo $x->:xhp-child->prop."\n";
+echo $x->:xhp-child->:foo-bar."\n";
+
+--EXPECT--
+pass
+prop
+pass

--- a/xhp/parser.y
+++ b/xhp/parser.y
@@ -1563,6 +1563,7 @@ object_dim_list:
     $$ = $1 + $2 + $3 + $4;
   }
 | variable_name
+| xhp_attribute_reference
 ;
 
 variable_name:
@@ -1802,6 +1803,13 @@ xhp_attributes:
   }
 | xhp_attributes xhp_attribute {
     $$ = $1 + $2 + ",";
+  }
+;
+
+// Attribute when referenced as an object property ($foo->:attr)
+xhp_attribute_reference:
+  ':' xhp_label_pass {
+    $$ = "getAttribute('" + $2 + "')";
   }
 ;
 

--- a/xhp/scanner.l
+++ b/xhp/scanner.l
@@ -550,6 +550,12 @@ NEWLINE ("\r\n"|"\n"|"\r")
 #endif
     return T_PAAMAYIM_NEKUDOTAYIM;
   }
+  "->" {
+    pop_state();
+    // Hack: Don't use tok() here because of PHP_NO_RESERVED_WORDS. See above.
+    *yylval = code_rope(yytext, yyextra->first_lineno, yyextra->lineno - yyextra->first_lineno);
+    return T_OBJECT_OPERATOR;
+  }
   "--" {
     pop_state();
     tok(T_DEC);


### PR DESCRIPTION
HHVM added syntactic sugar for accessing XHP attributes in facebook/hhvm@38669653bd5449c6d55afc2bed5364631579265b. This syntax essentially maps down to calling getAttribute() on the object. It's a bit strange that it relies on the "userspace" calls, but there's probably no (simple) better way.

Anyways, this adds the same syntax to the Zend PHP extension, plus a test to verify that it works.
