### PR TITLE
Add 'as' attribute to link tag

### DIFF
--- a/src/html/tags/l/Link.php
+++ b/src/html/tags/l/Link.php
@@ -11,6 +11,7 @@
 
 class :link extends :xhp:html-singleton {
   attribute
+    Stringish a,
     enum {'anonymous', 'use-credentials'} crossorigin,
     Stringish href,
     Stringish hreflang,

--- a/src/html/tags/l/Link.php
+++ b/src/html/tags/l/Link.php
@@ -11,7 +11,7 @@
 
 class :link extends :xhp:html-singleton {
   attribute
-    Stringish a,
+    Stringish as,
     enum {'anonymous', 'use-credentials'} crossorigin,
     Stringish href,
     Stringish hreflang,


### PR DESCRIPTION
`<link rel="preload" as="font" />` does not work. Need to support `as` attribute.