### PR TITLE
add spread operator support to xhp-lib

### DIFF
--- a/src/core/XHP.php
+++ b/src/core/XHP.php
@@ -10,6 +10,9 @@
  */
 
 abstract class :xhp implements XHPChild, JsonSerializable {
+  // Must be kept in sync with code generation for XHP
+  const string SPREAD_PREFIX = '...$';
+
   public function __construct(
     KeyedTraversable<string, mixed> $attributes,
     Traversable<XHPChild> $children,

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -401,4 +401,15 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
       "Incorrect reflection for unsupported `callable` attribute type",
     );
   }
+
+  public function testAttributeSpread(): void {
+    $x = <test:attribute-types mystring="foo" mybool={true} />;
+    $y = <test:attribute-types mystring="bar" {...$x} myint={5} />;
+    $this->assertSame('foo', $y->:mystring);
+    $this->assertSame(5, $y->:myint);
+    $this->assertSame(true, $y->:mybool);
+
+    $attrs = $y->getAttributes()->keys();
+    $this->assertEquals(Vector { 'mystring', 'mybool', 'myint' }, $attrs);
+  }
 }


### PR DESCRIPTION
Adds spread operator support for #188.

It works slightly differently than the internal version because xhp-lib is more pure when it comes to defaults and nulls, so this logic gets to be simplified quite a bit. Also, overriding this is not legal in xhp-lib since there are no extreme legacy use-cases that would need it.