### PR TITLE
Adding attribute to support the Subresource Integrity spec

### DIFF
--- a/src/html/tags/s/Script.php
+++ b/src/html/tags/s/Script.php
@@ -16,6 +16,7 @@ class :script extends :xhp:raw-pcdata-element {
     bool defer,
     Stringish src,
     Stringish type,
+    Stringish integrity,
     // Legacy
     Stringish language;
   category %flow, %phrase, %metadata;


### PR DESCRIPTION
Added `<script integrity="sha512-...">` per the [Subresource Integrity spec](https://www.w3.org/TR/SRI/#the-integrity-attribute)