### PR TITLE
Migrate assert to expect

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -5,4 +5,4 @@ disallow_non_arraykey_keys=true
 disallow_unsafe_comparisons=true
 decl_override_require_hint=true
 enable_experimental_tc_features=shape_field_check,sealed_classes
-forward_compatibility_level=20180704
+forward_compatibility_level=20180813

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "hhvm/hhvm-autoload": "^1.5"
     },
     "require-dev": {
+        "facebook/fbexpect": "^1.1.0",
         "phpunit/phpunit": "^5.1.0",
         "91carriage/phpunit-hhi": "^5.1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d877b247b58cfaedadaf442e2c9079ff",
+    "content-hash": "0ebe642347d82bb2a2eeba86adb97278",
     "packages": [
         {
             "name": "fredemmott/hack-error-suppressor",
@@ -95,16 +95,16 @@
         },
         {
             "name": "hhvm/hsl",
-            "version": "v3.27.0",
+            "version": "v3.27.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl.git",
-                "reference": "f43f027681402f0a6807325400a761106fa10274"
+                "reference": "c3d4725367c131c80dc65b765f9fdd6075475e63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl/zipball/f43f027681402f0a6807325400a761106fa10274",
-                "reference": "f43f027681402f0a6807325400a761106fa10274",
+                "url": "https://api.github.com/repos/hhvm/hsl/zipball/c3d4725367c131c80dc65b765f9fdd6075475e63",
+                "reference": "c3d4725367c131c80dc65b765f9fdd6075475e63",
                 "shasum": ""
             },
             "require": {
@@ -122,7 +122,7 @@
                 "MIT"
             ],
             "description": "The Hack Standard Library",
-            "time": "2018-06-07T01:25:22+00:00"
+            "time": "2018-08-08T16:18:28+00:00"
         },
         {
             "name": "hhvm/type-assert",
@@ -264,6 +264,42 @@
                 "instantiate"
             ],
             "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "facebook/fbexpect",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/fbexpect.git",
+                "reference": "5671bb1c7335b26de35a8049a680a8bad44c8b99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/5671bb1c7335b26de35a8049a680a8bad44c8b99",
+                "reference": "5671bb1c7335b26de35a8049a680a8bad44c8b99",
+                "shasum": ""
+            },
+            "require": {
+                "91carriage/phpunit-hhi": "^5.7",
+                "hhvm": "^3.23",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/expect.php",
+                    "src/utils.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Unit test helpers for Facebook projects",
+            "time": "2018-06-11T22:04:56+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -467,16 +503,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -488,12 +524,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -526,7 +562,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1433,25 +1469,28 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -1484,20 +1523,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.1.1",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "80e4bfa9685fc4a09acc4a857ec16974a9cd944e"
+                "reference": "46bc69aa91fc4ab78a96ce67873a6b0c148fd48c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/80e4bfa9685fc4a09acc4a857ec16974a9cd944e",
-                "reference": "80e4bfa9685fc4a09acc4a857ec16974a9cd944e",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/46bc69aa91fc4ab78a96ce67873a6b0c148fd48c",
+                "reference": "46bc69aa91fc4ab78a96ce67873a6b0c148fd48c",
                 "shasum": ""
             },
             "require": {
@@ -1543,7 +1582,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-30T07:26:09+00:00"
+            "time": "2018-07-26T11:24:31+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class :async:test extends :x:element {
   use XHPAsync;
 
@@ -52,38 +54,38 @@ class :async:par-test extends :x:element {
 class AsyncTest extends PHPUnit_Framework_TestCase {
   public function testDiv() {
     $xhp = <async:test>Herp</async:test>;
-    $this->assertEquals('<div>Herp</div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div>Herp</div>');
   }
 
   public function testXFrag() {
     $frag = <x:frag>{1}{2}</x:frag>;
     $xhp = <async:test>{$frag}</async:test>;
-    $this->assertEquals('<div>12</div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div>12</div>');
   }
 
   public function testNested() {
     $xhp = <async:test><async:test>herp derp</async:test></async:test>;
-    $this->assertEquals('<div><div>herp derp</div></div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div><div>herp derp</div></div>');
   }
 
   public function testEmpty() {
     $xhp = <async:test />;
-    $this->assertEquals('<div></div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div></div>');
   }
 
   public function testNestedEmpty() {
     $xhp = <async:test><async:test /></async:test>;
-    $this->assertEquals('<div><div></div></div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div><div></div></div>');
   }
 
   public function testNestedWithNonAsyncChild() {
     $xhp = <async:test><b>BE BOLD</b></async:test>;
-    $this->assertEquals('<div><b>BE BOLD</b></div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div><b>BE BOLD</b></div>');
   }
 
   public function testInstanceOfInterface() {
     $xhp = <async:test><b>BE BOLD</b></async:test>;
-    $this->assertInstanceOf(XHPAwaitable::class, $xhp);
+    expect($xhp)->toBeInstanceOf(XHPAwaitable::class);
   }
 
   public function parallelizationContainersProvider() {
@@ -103,9 +105,8 @@ class AsyncTest extends PHPUnit_Framework_TestCase {
     $container->replaceChildren([$b, $c]);
 
     $tree = <async:test>{$a}{$container}</async:test>;
-    $this->assertSame(
+    expect($tree->toString())->toBeSame(
       '<div><div>a</div><div>b</div><div>c</div></div>',
-      $tree->toString(),
     );
 
     $log = :async:par-test::$log;
@@ -121,19 +122,16 @@ class AsyncTest extends PHPUnit_Framework_TestCase {
     $max_mid = max($by_node->map($x ==> $x['mid']));
     $min_finish = min($by_node->map($x ==> $x['finish']));
 
-    $this->assertGreaterThan(
+    expect($min_mid)->toBeGreaterThan(
       $max_start,
-      $min_mid,
       'all should be started before any get continued',
     );
-    $this->assertGreaterThan(
+    expect($min_finish)->toBeGreaterThan(
       $max_mid,
-      $min_finish,
       'all should have reached stage two before any finish',
     );
-    $this->assertGreaterThan(
+    expect($min_finish)->toBeGreaterThan(
       $max_start,
-      $min_finish,
       'sanity check: all have started before any finish',
     );
   }

--- a/tests/AttributesCoercionModeTest.php
+++ b/tests/AttributesCoercionModeTest.php
@@ -7,6 +7,8 @@
  *  LICENSE file in the root directory of this source tree.
  *
  */
+
+use function Facebook\FBExpect\expect;
 // Using decl because this test intentional passes the wrong types for
 // attributes
 
@@ -49,10 +51,10 @@ class AttributesCoercionModeTest extends PHPUnit_Framework_TestCase {
         mystring="foo"
         mybool={true}
       />;
-    $this->assertSame(3, $x->:myint);
-    $this->assertSame(1.23, $x->:myfloat);
-    $this->assertSame('foo', $x->:mystring);
-    $this->assertSame(true, $x->:mybool);
+    expect($x->:myint)->toBeSame(3);
+    expect($x->:myfloat)->toBeSame(1.23);
+    expect($x->:mystring)->toBeSame('foo');
+    expect($x->:mybool)->toBeSame(true);
   }
 
   /**
@@ -107,7 +109,7 @@ class AttributesCoercionModeTest extends PHPUnit_Framework_TestCase {
     error_reporting(E_ALL);
     XHPAttributeCoercion::SetMode(XHPAttributeCoercionMode::SILENT);
     $x = <test:attribute-coercion-modes mystring={2} />;
-    $this->assertSame('2', $x->:mystring);
+    expect($x->:mystring)->toBeSame('2');
   }
 
   public function testLoggingDeprecationCoercion(): void {
@@ -119,10 +121,10 @@ class AttributesCoercionModeTest extends PHPUnit_Framework_TestCase {
     } catch (Exception $e) {
       $exception = $e;
     }
-    $this->assertInstanceOf('PHPUnit_Framework_Error_Deprecated', $exception);
+    expect($exception)->toBeInstanceOf('PHPUnit_Framework_Error_Deprecated');
 
     error_reporting(E_ALL & ~E_USER_DEPRECATED);
     $x = <test:attribute-coercion-modes mystring={2} />;
-    $this->assertSame('2', $x->:mystring);
+    expect($x->:mystring)->toBeSame('2');
   }
 }

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 type TMyTestShape = shape('foo' => string, 'bar' => ?string);
 class :test:attribute-types extends :x:element {
   attribute
@@ -87,7 +89,7 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
         mymap={Map { 'herp' => 'derp' }}
         myshape={shape('foo' => 'herp', 'bar' => 'derp')}
       />;
-    $this->assertEquals('<div></div>', $x->toString());
+    expect($x->toString())->toBePHPEqual('<div></div>');
   }
 
   public function testShapeWithExtraKey(): void {
@@ -100,7 +102,7 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
         /* HH_IGNORE_ERROR[4166] */
         myshape={shape('foo' => 'herp', 'bar' => 'derp', 'baz' => 'extra')}
       />;
-    $this->assertEquals('<div></div>', $x->toString());
+    expect($x->toString())->toBePHPEqual('<div></div>');
   }
 
   public function testShapeWithMissingOptionalKey(): void {
@@ -110,7 +112,7 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
 
     /* HH_IGNORE_ERROR[4057] */
     $x = <test:attribute-types myshape={shape('foo' => 'herp')} />;
-    $this->assertEquals('<div></div>', $x->toString());
+    expect($x->toString())->toBePHPEqual('<div></div>');
   }
 
   public function testShapeWithMissingRequiredKey(): void {
@@ -121,9 +123,9 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
 
   public function testValidArrayKeys(): void {
     $x = <test:attribute-types myarraykey="foo" />;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
     $x = <test:attribute-types myarraykey={123} />;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
   }
 
   /**
@@ -137,9 +139,9 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
 
   public function testValidNum(): void {
     $x = <test:attribute-types mynum={123} />;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
     $x = <test:attribute-types mynum={1.23} />;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
   }
 
   /**
@@ -152,19 +154,19 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testNoAttributes(): void {
-    $this->assertEquals('<div></div>', <test:attribute-types />);
+    expect(<test:attribute-types />)->toBePHPEqual('<div></div>');
   }
 
   public function testStringableObjectAsString(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types mystring={new StringableTestClass()} />;
-    $this->assertSame('StringableTestClass', $x->:mystring);
+    expect($x->:mystring)->toBeSame('StringableTestClass');
   }
 
   public function testIntegerAsString(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types mystring={123} />;
-    $this->assertSame('123', $x->:mystring);
+    expect($x->:mystring)->toBeSame('123');
   }
 
   /**
@@ -194,19 +196,19 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
   public function testIntishStringAsInt(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types myint={'123'} />;
-    $this->assertSame(123, $x->:myint);
+    expect($x->:myint)->toBeSame(123);
   }
 
   public function testFloatAsInt(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types myint={1.23} />;
-    $this->assertSame(1, $x->:myint);
+    expect($x->:myint)->toBeSame(1);
   }
 
   public function testFloatishStringAsInt(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types myint="1.23" />;
-    $this->assertSame(1, $x->:myint);
+    expect($x->:myint)->toBeSame(1);
   }
 
   /**
@@ -244,13 +246,13 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
   public function testTrueStringAsBool(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types mybool="true" />;
-    $this->assertSame(true, $x->:mybool);
+    expect($x->:mybool)->toBeSame(true);
   }
 
   public function testFalseStringAsBool(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types mybool="false" />;
-    $this->assertSame(false, $x->:mybool);
+    expect($x->:mybool)->toBeSame(false);
   }
 
   /**
@@ -275,7 +277,7 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
     // idiomatic - eg checked="checked"
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types mybool="mybool" />;
-    $this->assertSame(true, $x->:mybool);
+    expect($x->:mybool)->toBeSame(true);
   }
 
   /**
@@ -288,16 +290,16 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
   public function testIntAsFloat(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types myfloat={123} />;
-    $this->assertSame(123.0, $x->:myfloat);
+    expect($x->:myfloat)->toBeSame(123.0);
   }
 
   public function testNumericStringsAsFloats(): void {
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types myfloat="123" />;
-    $this->assertSame(123.0, $x->:myfloat);
+    expect($x->:myfloat)->toBeSame(123.0);
     /* HH_IGNORE_ERROR[4110] */
     $x = <test:attribute-types myfloat="1.23" />;
-    $this->assertSame(1.23, $x->:myfloat);
+    expect($x->:myfloat)->toBeSame(1.23);
   }
 
   /**
@@ -350,8 +352,8 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
 
   public function testProvidingRequiredAttributes(): void {
     $x = <test:required-attributes mystring="herp" />;
-    $this->assertSame('herp', $x->:mystring);
-    $this->assertSame('<div>herp</div>', $x->toString());
+    expect($x->:mystring)->toBeSame('herp');
+    expect($x->toString())->toBeSame('<div>herp</div>');
   }
 
   /**
@@ -359,19 +361,19 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
    */
   public function testOmittingRequiredAttributes(): void {
     $x = <test:required-attributes />;
-    $this->assertNull($x->:mystring);
+    expect($x->:mystring)->toBeNull();
   }
 
   public function testProvidingDefaultAttributes(): void {
     $x = <test:default-attributes mystring="herp" />;
-    $this->assertSame('herp', $x->:mystring);
-    $this->assertSame('<div>herp</div>', $x->toString());
+    expect($x->:mystring)->toBeSame('herp');
+    expect($x->toString())->toBeSame('<div>herp</div>');
   }
 
   public function testOmittingDefaultAttributes(): void {
     $x = <test:default-attributes />;
-    $this->assertSame('mydefault', $x->:mystring);
-    $this->assertSame('<div>mydefault</div>', $x->toString());
+    expect($x->:mystring)->toBeSame('mydefault');
+    expect($x->toString())->toBeSame('<div>mydefault</div>');
   }
 
   /**
@@ -384,9 +386,9 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
 
   public function testSpecialAttributes(): void {
     $x = <test:default-attributes data-idonotexist="derp" />;
-    $this->assertSame('<div>mydefault</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>mydefault</div>');
     $x = <test:default-attributes aria-idonotexist="derp" />;
-    $this->assertSame('<div>mydefault</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>mydefault</div>');
   }
 
   /**
@@ -395,7 +397,7 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
   public function testRenderCallableAttribute(): void {
     $x =
       <test:callable-attribute
-    /* HH_IGNORE_ERROR[4110] */
+        /* HH_IGNORE_ERROR[4110] */
         foo={function() {
         }}
       />;
@@ -404,20 +406,20 @@ class AttributesTest extends PHPUnit_Framework_TestCase {
   public function testReflectOnCallableAttribute(): void {
     $rxhp = new ReflectionXHPClass(:test:callable-attribute::class);
     $rattr = $rxhp->getAttribute('foo');
-    $this->assertTrue(
-      strstr((string)$rattr, "<UNSUPPORTED: legacy callable>") !== false,
-      "Incorrect reflection for unsupported `callable` attribute type",
-    );
+    expect(strstr((string)$rattr, "<UNSUPPORTED: legacy callable>") !== false)
+      ->toBeTrue(
+        "Incorrect reflection for unsupported `callable` attribute type",
+      );
   }
 
   public function testAttributeSpread(): void {
     $x = <test:attribute-types mystring="foo" mybool={true} />;
     $y = <test:attribute-types mystring="bar" {...$x} myint={5} />;
-    $this->assertSame('foo', $y->:mystring);
-    $this->assertSame(5, $y->:myint);
-    $this->assertSame(true, $y->:mybool);
+    expect($y->:mystring)->toBeSame('foo');
+    expect($y->:myint)->toBeSame(5);
+    expect($y->:mybool)->toBeSame(true);
 
     $attrs = $y->getAttributes()->keys();
-    $this->assertEquals(Vector { 'mystring', 'mybool', 'myint' }, $attrs);
+    expect($attrs)->toBePHPEqual(Vector { 'mystring', 'mybool', 'myint' });
   }
 }

--- a/tests/BasicsTest.php
+++ b/tests/BasicsTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class :test:renders-primitive extends :x:element {
   protected function render(): XHPRoot {
     return <x:frag><div>123</div></x:frag>;
@@ -20,54 +22,54 @@ class BasicsTest extends PHPUnit_Framework_TestCase {
       <div>
         Hello, world.
       </div>;
-    $this->assertEquals('<div> Hello, world. </div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div> Hello, world. </div>');
   }
 
   public function testFragWithString() {
     $xhp = <x:frag>Derp</x:frag>;
-    $this->assertSame('Derp', $xhp->toString());
+    expect($xhp->toString())->toBeSame('Derp');
   }
 
   public function testDivWithChild() {
     $xhp = <div><div>Herp</div></div>;
-    $this->assertEquals('<div><div>Herp</div></div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div><div>Herp</div></div>');
   }
 
   public function testInterpolation() {
     $x = "Herp";
     $xhp = <div>{$x}</div>;
-    $this->assertEquals('<div>Herp</div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div>Herp</div>');
   }
 
   public function testXFrag() {
     $x = 'herp';
     $y = 'derp';
     $frag = <x:frag>{$x}{$y}</x:frag>;
-    $this->assertEquals(2, $frag->getChildren()->count());
+    expect($frag->getChildren()->count())->toBePHPEqual(2);
     $xhp = <div>{$frag}</div>;
-    $this->assertEquals('<div>herpderp</div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div>herpderp</div>');
   }
 
   public function testEscaping() {
     $xhp = <div>{"foo<SCRIPT>bar"}</div>;
-    $this->assertEquals('<div>foo&lt;SCRIPT&gt;bar</div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<div>foo&lt;SCRIPT&gt;bar</div>');
   }
 
   public function testElement2Class(): void {
-    $this->assertSame(:div::class, :xhp::element2class('div'));
+    expect(:xhp::element2class('div'))->toBeSame(:div::class);
   }
 
   public function testClass2Element(): void {
-    $this->assertSame('div', :xhp::class2element(:div::class));
+    expect(:xhp::class2element(:div::class))->toBeSame('div');
   }
 
   public function testRendersPrimitive(): void {
     $xhp = <test:renders-primitive />;
-    $this->assertSame('<div>123</div>', $xhp->toString());
+    expect($xhp->toString())->toBeSame('<div>123</div>');
   }
 
   public function testJsonSerialize(): void {
     $xhp = <div>Hello world.</div>;
-    $this->assertSame('["<div>Hello world.<\/div>"]', json_encode([$xhp]));
+    expect(json_encode([$xhp]))->toBeSame('["<div>Hello world.<\/div>"]');
   }
 }

--- a/tests/ChildRuleTest.php
+++ b/tests/ChildRuleTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class :test:any-children extends :x:element {
   children any;
   protected function render(): XHPRoot {
@@ -106,14 +108,11 @@ class :test:needs-comma-category extends :x:element {
 
 class ChildRuleTest extends PHPUnit_Framework_TestCase {
   public function testNoChild(): void {
-    $elems = Vector {
-      <test:no-children />,
-      <test:any-children />,
-      <test:optional-child />,
-      <test:any-number-of-child />,
+    $elems = Vector { <test:no-children />, <test:any-children />,
+    <test:optional-child />, <test:any-number-of-child />,
     };
     foreach ($elems as $elem) {
-      $this->assertSame('<div></div>', (string)$elem);
+      expect((string)$elem)->toBeSame('<div></div>');
     }
   }
 
@@ -126,19 +125,14 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testSingleChild(): void {
-    $elems = Vector {
-      <test:any-children />,
-      <test:single-child />,
-      <test:optional-child />,
-      <test:any-number-of-child />,
-      <test:at-least-one-child />,
-      <test:either-of-two-children />,
-      <test:nested-rule />,
-      <test:category-child />,
+    $elems = Vector { <test:any-children />, <test:single-child />,
+    <test:optional-child />, <test:any-number-of-child />,
+    <test:at-least-one-child />, <test:either-of-two-children />,
+    <test:nested-rule />, <test:category-child />,
     };
     foreach ($elems as $elem) {
       $elem->appendChild(<div>Foo</div>);
-      $this->assertSame('<div></div>', (string)$elem);
+      expect((string)$elem)->toBeSame('<div></div>');
     }
   }
 
@@ -149,7 +143,7 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
     :x:composable-element $elem,
     string $expected,
   ): void {
-    $this->assertSame($expected, $elem->__getChildrenDeclaration());
+    expect($elem->__getChildrenDeclaration())->toBeSame($expected);
   }
 
   public function toStringProvider() {
@@ -169,12 +163,9 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testExpectedChild(): void {
-    $elems = Vector {
-      <test:single-child />,
-      <test:at-least-one-child />,
-      <test:either-of-two-children />,
-      <test:nested-rule />,
-      <test:pcdata-child />,
+    $elems = Vector { <test:single-child />, <test:at-least-one-child />,
+    <test:either-of-two-children />, <test:nested-rule />,
+    <test:pcdata-child />,
     };
     foreach ($elems as $elem) {
       $exception = null;
@@ -183,18 +174,14 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
       } catch (Exception $e) {
         $exception = $e;
       }
-      $this->assertInstanceOf(XHPInvalidChildrenException::class, $exception);
+      expect($exception)->toBeInstanceOf(XHPInvalidChildrenException::class);
     }
   }
 
   public function testTooManyChildren(): void {
-    $elems = Vector {
-      <test:single-child />,
-      <test:optional-child />,
-      <test:two-children />,
-      <test:either-of-two-children />,
-      <test:nested-rule />,
-      <test:category-child />,
+    $elems = Vector { <test:single-child />, <test:optional-child />,
+    <test:two-children />, <test:either-of-two-children />,
+    <test:nested-rule />, <test:category-child />,
     };
     foreach ($elems as $elem) {
       $exception = null;
@@ -204,19 +191,15 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
       } catch (Exception $e) {
         $exception = $e;
       }
-      $this->assertInstanceOf(XHPInvalidChildrenException::class, $exception);
+      expect($exception)->toBeInstanceOf(XHPInvalidChildrenException::class);
     }
   }
 
   public function testIncorrectChild(): void {
-    $elems = Vector {
-      <test:single-child />,
-      <test:optional-child />,
-      <test:any-number-of-child />,
-      <test:at-least-one-child />,
-      <test:either-of-two-children />,
-      <test:nested-rule />,
-      <test:category-child />,
+    $elems = Vector { <test:single-child />, <test:optional-child />,
+    <test:any-number-of-child />, <test:at-least-one-child />,
+    <test:either-of-two-children />, <test:nested-rule />,
+    <test:category-child />,
     };
     foreach ($elems as $elem) {
       $exception = null;
@@ -226,19 +209,17 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
       } catch (Exception $e) {
         $exception = $e;
       }
-      $this->assertInstanceOf(XHPInvalidChildrenException::class, $exception);
+      expect($exception)->toBeInstanceOf(XHPInvalidChildrenException::class);
     }
   }
 
   public function testTwoChildren(): void {
-    $elems = Vector {
-      <test:any-number-of-child />,
-      <test:at-least-one-child />,
-      <test:two-children />,
+    $elems = Vector { <test:any-number-of-child />, <test:at-least-one-child />,
+    <test:two-children />,
     };
     foreach ($elems as $elem) {
       $elem->appendChild(<x:frag><div /><div /></x:frag>);
-      $this->assertSame('<div></div>', $elem->toString());
+      expect($elem->toString())->toBeSame('<div></div>');
     }
   }
 
@@ -247,29 +228,29 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
       Vector { <test:any-number-of-child />, <test:at-least-one-child /> };
     foreach ($elems as $elem) {
       $elem->appendChild(<x:frag><div /><div /><div /></x:frag>);
-      $this->assertSame('<div></div>', $elem->toString());
+      expect($elem->toString())->toBeSame('<div></div>');
     }
   }
 
   public function testEitherValidChild(): void {
     $x = <test:either-of-two-children><div /></test:either-of-two-children>;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
     $x = <test:either-of-two-children><code /></test:either-of-two-children>;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
 
     $x = <test:nested-rule><div /></test:nested-rule>;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
     $x = <test:nested-rule><code /></test:nested-rule>;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
     $x = <test:nested-rule><code /><code /></test:nested-rule>;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
   }
 
   public function testPCDataChild(): void {
     $x = <test:pcdata-child>herp derp</test:pcdata-child>;
-    $this->assertSame('<div>herp derp</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>herp derp</div>');
     $x = <test:pcdata-child>{123}</test:pcdata-child>;
-    $this->assertSame('<div>123</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>123</div>');
   }
 
   public function testCommaCategory(): void {
@@ -277,12 +258,12 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
       <test:needs-comma-category>
         <test:has-comma-category />
       </test:needs-comma-category>;
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
   }
 
   public function testFrags(): void {
     $x = <div><x:frag>{'foo'}{'bar'}</x:frag></div>;
-    $this->assertSame('<div>foobar</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>foobar</div>');
   }
 
   /**

--- a/tests/ChildRuleTest.php
+++ b/tests/ChildRuleTest.php
@@ -108,8 +108,11 @@ class :test:needs-comma-category extends :x:element {
 
 class ChildRuleTest extends PHPUnit_Framework_TestCase {
   public function testNoChild(): void {
-    $elems = Vector { <test:no-children />, <test:any-children />,
-    <test:optional-child />, <test:any-number-of-child />,
+    $elems = Vector {
+      <test:no-children />,
+      <test:any-children />,
+      <test:optional-child />,
+      <test:any-number-of-child />,
     };
     foreach ($elems as $elem) {
       expect((string)$elem)->toBeSame('<div></div>');
@@ -125,10 +128,15 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testSingleChild(): void {
-    $elems = Vector { <test:any-children />, <test:single-child />,
-    <test:optional-child />, <test:any-number-of-child />,
-    <test:at-least-one-child />, <test:either-of-two-children />,
-    <test:nested-rule />, <test:category-child />,
+    $elems = Vector {
+      <test:any-children />,
+      <test:single-child />,
+      <test:optional-child />,
+      <test:any-number-of-child />,
+      <test:at-least-one-child />,
+      <test:either-of-two-children />,
+      <test:nested-rule />,
+      <test:category-child />,
     };
     foreach ($elems as $elem) {
       $elem->appendChild(<div>Foo</div>);
@@ -137,7 +145,7 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @dataProvider toStringProvider 
+   * @dataProvider toStringProvider
    */
   public function testToString(
     :x:composable-element $elem,
@@ -163,9 +171,12 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testExpectedChild(): void {
-    $elems = Vector { <test:single-child />, <test:at-least-one-child />,
-    <test:either-of-two-children />, <test:nested-rule />,
-    <test:pcdata-child />,
+    $elems = Vector {
+      <test:single-child />,
+      <test:at-least-one-child />,
+      <test:either-of-two-children />,
+      <test:nested-rule />,
+      <test:pcdata-child />,
     };
     foreach ($elems as $elem) {
       $exception = null;
@@ -179,9 +190,13 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testTooManyChildren(): void {
-    $elems = Vector { <test:single-child />, <test:optional-child />,
-    <test:two-children />, <test:either-of-two-children />,
-    <test:nested-rule />, <test:category-child />,
+    $elems = Vector {
+      <test:single-child />,
+      <test:optional-child />,
+      <test:two-children />,
+      <test:either-of-two-children />,
+      <test:nested-rule />,
+      <test:category-child />,
     };
     foreach ($elems as $elem) {
       $exception = null;
@@ -196,10 +211,14 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testIncorrectChild(): void {
-    $elems = Vector { <test:single-child />, <test:optional-child />,
-    <test:any-number-of-child />, <test:at-least-one-child />,
-    <test:either-of-two-children />, <test:nested-rule />,
-    <test:category-child />,
+    $elems = Vector {
+      <test:single-child />,
+      <test:optional-child />,
+      <test:any-number-of-child />,
+      <test:at-least-one-child />,
+      <test:either-of-two-children />,
+      <test:nested-rule />,
+      <test:category-child />,
     };
     foreach ($elems as $elem) {
       $exception = null;
@@ -214,8 +233,10 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testTwoChildren(): void {
-    $elems = Vector { <test:any-number-of-child />, <test:at-least-one-child />,
-    <test:two-children />,
+    $elems = Vector {
+      <test:any-number-of-child />,
+      <test:at-least-one-child />,
+      <test:two-children />,
     };
     foreach ($elems as $elem) {
       $elem->appendChild(<x:frag><div /><div /></x:frag>);

--- a/tests/ContextsTest.php
+++ b/tests/ContextsTest.php
@@ -8,11 +8,13 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class :test:contexts extends :x:element {
   protected function render(): XHPRoot {
     return
       <div>
-        <p>{(string) $this->getContext('heading')}</p>
+        <p>{(string)$this->getContext('heading')}</p>
         {$this->getChildren()}
       </div>;
   }
@@ -22,21 +24,20 @@ class XHPContextsTest extends PHPUnit_Framework_TestCase {
   public function testContextSimple(): void {
     $x = <test:contexts />;
     $x->setContext('heading', 'herp');
-    $this->assertSame('<div><p>herp</p></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div><p>herp</p></div>');
   }
 
   public function testContextInsideHTMLElement(): void {
     $x = <div><test:contexts /></div>;
     $x->setContext('heading', 'herp');
-    $this->assertSame('<div><div><p>herp</p></div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div><div><p>herp</p></div></div>');
   }
 
   public function testNestedContexts(): void {
     $x = <test:contexts><test:contexts /></test:contexts>;
     $x->setContext('heading', 'herp');
-    $this->assertSame(
+    expect($x->toString())->toBeSame(
       '<div><p>herp</p><div><p>herp</p></div></div>',
-      $x->toString(),
     );
   }
 }

--- a/tests/HackEnumAttributeTest.php
+++ b/tests/HackEnumAttributeTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 enum TestEnum: int {
   HERP = 1;
   DERP = 2;
@@ -32,17 +34,17 @@ class HackEnumAttributesTest extends PHPUnit_Framework_TestCase {
 
   public function testValidValues(): void {
     $x = <test:hack-enum-attribute foo={TestEnum::HERP} />;
-    $this->assertSame('<div>HERP</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>HERP</div>');
     $x = <test:hack-enum-attribute foo={TestEnum::DERP} />;
-    $this->assertSame('<div>DERP</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>DERP</div>');
   }
 
   public function testValidRawValues(): void {
     // UNSAFE
     $x = <test:hack-enum-attribute foo={1} />;
-    $this->assertSame('<div>HERP</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>HERP</div>');
     $x = <test:hack-enum-attribute foo={2} />;
-    $this->assertSame('<div>DERP</div>', $x->toString());
+    expect($x->toString())->toBeSame('<div>DERP</div>');
   }
 
   /**

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class :test:for-reflection extends :x:element {
   attribute
     string mystring @required,
@@ -29,40 +31,39 @@ class ReflectionTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testClassName(): void {
-    $this->assertSame(:test:for-reflection::class, $this->rxc?->getClassName());
+    expect($this->rxc?->getClassName())->toBeSame(:test:for-reflection::class);
   }
 
   public function testElementName(): void {
-    $this->assertSame('test:for-reflection', $this->rxc?->getElementName());
+    expect($this->rxc?->getElementName())->toBeSame('test:for-reflection');
   }
 
   public function testReflectionClass(): void {
     $rc = $this->rxc?->getReflectionClass();
-    $this->assertInstanceOf(ReflectionClass::class, $rc);
-    $this->assertSame(:test:for-reflection::class, $rc?->getName());
+    expect($rc)->toBeInstanceOf(ReflectionClass::class);
+    expect($rc?->getName())->toBeSame(:test:for-reflection::class);
   }
 
   public function testGetChildren(): void {
     $children = $this->rxc?->getChildren();
-    $this->assertInstanceOf(ReflectionXHPChildrenDeclaration::class, $children);
-    $this->assertSame('(:div+,(:code,:a)?)', (string)$children);
+    expect($children)->toBeInstanceOf(ReflectionXHPChildrenDeclaration::class);
+    expect((string)$children)->toBeSame('(:div+,(:code,:a)?)');
   }
 
   public function testGetAttributes(): void {
     $attrs = $this->rxc?->getAttributes();
-    $this->assertNotEmpty($attrs);
-    $this->assertEquals(
+    expect($attrs)->toNotBeEmpty();
+    expect($attrs?->map($attr ==> (string)$attr))->toBePHPEqual(
       Map {
         'mystring' => 'string mystring @required',
         'myenum' => "enum {'herp', 'derp'} myenum",
         'mystringwithdefault' => "string mystringwithdefault = 'mydefault'",
       },
-      $attrs?->map($attr ==> (string)$attr),
     );
   }
 
   public function testGetCategories(): void {
     $categories = $this->rxc?->getCategories();
-    $this->assertEquals(Set { 'herp', 'derp' }, $categories);
+    expect($categories)->toBePHPEqual(Set { 'herp', 'derp' });
   }
 }

--- a/tests/TestChildFlushing.php
+++ b/tests/TestChildFlushing.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class :test:verbatim-root extends :x:element {
   attribute XHPRoot root @required;
 
@@ -52,7 +54,7 @@ class XHPChildFlushTest extends PHPUnit_Framework_TestCase {
   public function testSynchronous(XHPRoot $root, string $expected) {
     $elem = <test:verbatim-root />;
     $elem->setContext('root', $root);
-    $this->assertSame($expected, $elem->toString());
+    expect($elem->toString())->toBeSame($expected);
   }
 
   /**
@@ -61,6 +63,6 @@ class XHPChildFlushTest extends PHPUnit_Framework_TestCase {
   public function testAsynchronous(XHPRoot $root, string $expected) {
     $elem = <test:verbatim-root:async />;
     $elem->setContext('root', $root);
-    $this->assertSame($expected, $elem->toString());
+    expect($elem->toString())->toBeSame($expected);
   }
 }

--- a/tests/UnsafeInterfacesTest.php
+++ b/tests/UnsafeInterfacesTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 // Please see MIGRATING.md for information on how these should be used in
 // practice; please don't create/use classes as unsafe as these examples.
 
@@ -20,7 +22,8 @@ class ExampleUnsafeRenderable implements XHPUnsafeRenderable {
   }
 }
 
-class ExampleVeryUnsafeRenderable extends ExampleUnsafeRenderable
+class ExampleVeryUnsafeRenderable
+  extends ExampleUnsafeRenderable
   implements XHPUnsafeRenderable, XHPAlwaysValidChild {
 }
 
@@ -37,9 +40,8 @@ class UnsafeInterfacesTest extends PHPUnit_Framework_TestCase {
   public function testUnsafeRenderable() {
     $x = new ExampleUnsafeRenderable('<script>lollerskates</script>');
     $xhp = <div>{$x}</div>;
-    $this->assertEquals(
+    expect($xhp->toString())->toBePHPEqual(
       '<div><script>lollerskates</script></div>',
-      $xhp->toString(),
     );
   }
 
@@ -55,19 +57,22 @@ class UnsafeInterfacesTest extends PHPUnit_Framework_TestCase {
   public function testAlwaysValidChild() {
     $x = new ExampleVeryUnsafeRenderable('foo');
     $xhp = <html>{$x}<body /></html>;
-    $this->assertEquals('<html>foo<body></body></html>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual('<html>foo<body></body></html>');
   }
 
   public function testUnsafeAttribute(): void {
     // without using XHPUnsafeAttributeValue, each &amp; will be double-escaped as &amp;amp;
     $attr = "foo &amp;&amp; bar";
     $xhp = <div onclick={$attr} />;
-    $this->assertEquals('<div onclick="foo &amp;amp;&amp;amp; bar"></div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual(
+      '<div onclick="foo &amp;amp;&amp;amp; bar"></div>',
+    );
 
     // using XHPUnsafeAttributeValue the &amp; is not double escaped
     $escaped = new ExampleUnsafeAttribute("foo &amp;&amp; bar");
     $xhp = <div onclick={$escaped} />;
-    $this->assertEquals('<div onclick="foo &amp;&amp; bar"></div>', $xhp->toString());
+    expect($xhp->toString())->toBePHPEqual(
+      '<div onclick="foo &amp;&amp; bar"></div>',
+    );
   }
 }
-

--- a/tests/XHPHelpersTest.php
+++ b/tests/XHPHelpersTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class :test:no-xhphelpers extends :x:element {
   use XHPBaseHTMLHelpers;
   attribute :xhp:html-element;
@@ -58,30 +60,30 @@ class :test:with-class-on-root extends :x:element {
 class XHPHelpersTest extends PHPUnit_Framework_TestCase {
   public function testTransferAttributesWithoutHelpers(): void {
     $x = <test:no-xhphelpers data-foo="bar" />;
-    $this->assertSame('<div></div>', $x->toString());
-    $this->assertNotEmpty($x->getID());
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
+    expect($x->getID())->toNotBeEmpty();
+    expect($x->toString())->toBeSame('<div></div>');
   }
 
   public function testTransferAttributesAsyncWithoutHelpers(): void {
     $x = <test:async:no-xhphelpers data-foo="bar" />;
-    $this->assertSame('<div></div>', $x->toString());
-    $this->assertNotEmpty($x->getID());
-    $this->assertSame('<div></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div></div>');
+    expect($x->getID())->toNotBeEmpty();
+    expect($x->toString())->toBeSame('<div></div>');
   }
 
   public function testTransferAttributesWithHelpers(): void {
     $x = <test:xhphelpers data-foo="bar" />;
-    $this->assertSame('<div data-foo="bar"></div>', $x->toString());
-    $this->assertNotEmpty($x->getID());
-    $this->assertSame('<div id="'.$x->getID().'"></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div data-foo="bar"></div>');
+    expect($x->getID())->toNotBeEmpty();
+    expect('<div id="'.$x->getID().'"></div>')->toBeSame($x->toString());
   }
 
   public function testTransferAttributesAsyncWithHelpers(): void {
     $x = <test:async:xhphelpers data-foo="bar" />;
-    $this->assertSame('<div data-foo="bar"></div>', $x->toString());
-    $this->assertNotEmpty($x->getID());
-    $this->assertSame('<div id="'.$x->getID().'"></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div data-foo="bar"></div>');
+    expect($x->getID())->toNotBeEmpty();
+    expect('<div id="'.$x->getID().'"></div>')->toBeSame($x->toString());
   }
 
   public function testAddClassWithoutHelpers(): void {
@@ -89,8 +91,8 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
     $x->addClass("bar");
     $x->conditionClass(true, "herp");
     $x->conditionClass(false, "derp");
-    $this->assertSame('foo bar herp', $x->:class);
-    $this->assertSame("<div></div>", $x->toString());
+    expect($x->:class)->toBeSame('foo bar herp');
+    expect($x->toString())->toBeSame("<div></div>");
   }
 
   public function testAddClassWithHelpers(): void {
@@ -98,26 +100,25 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
     $x->addClass("bar");
     $x->conditionClass(true, "herp");
     $x->conditionClass(false, "derp");
-    $this->assertSame('foo bar herp', $x->:class);
-    $this->assertSame('<div class="foo bar herp"></div>', $x->toString());
+    expect($x->:class)->toBeSame('foo bar herp');
+    expect($x->toString())->toBeSame('<div class="foo bar herp"></div>');
   }
 
   public function testRootClassPreserved(): void {
     $x = <test:with-class-on-root />;
-    $this->assertSame('<div class="rootClass"></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div class="rootClass"></div>');
   }
 
   public function testTransferedClassesAppended(): void {
     $x = <test:with-class-on-root class="extraClass" />;
-    $this->assertSame(
-      '<div class="rootClass extraClass"></div>',
-      $x->toString(),
-    );
+    expect(      $x->toString(),
+)->toBeSame(
+      '<div class="rootClass extraClass"></div>'    );
   }
 
   public function testRootClassesNotOverridenByEmptyString(): void {
     $x = <test:with-class-on-root class="" />;
-    $this->assertSame('<div class="rootClass"></div>', $x->toString());
+    expect($x->toString())->toBeSame('<div class="rootClass"></div>');
   }
 
   public function testNested(): void {
@@ -125,9 +126,8 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
       <test:xhphelpers class="herp">
         <test:xhphelpers class="derp" />
       </test:xhphelpers>;
-    $this->assertSame(
-      '<div class="herp"><div class="derp"></div></div>',
-      $x->toString(),
-    );
+    expect(      $x->toString(),
+)->toBeSame(
+      '<div class="herp"><div class="derp"></div></div>'    );
   }
 }

--- a/tests/XHPHelpersTest.php
+++ b/tests/XHPHelpersTest.php
@@ -111,9 +111,9 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
 
   public function testTransferedClassesAppended(): void {
     $x = <test:with-class-on-root class="extraClass" />;
-    expect(      $x->toString(),
-)->toBeSame(
-      '<div class="rootClass extraClass"></div>'    );
+    expect($x->toString())->toBeSame(
+      '<div class="rootClass extraClass"></div>',
+    );
   }
 
   public function testRootClassesNotOverridenByEmptyString(): void {
@@ -126,8 +126,8 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
       <test:xhphelpers class="herp">
         <test:xhphelpers class="derp" />
       </test:xhphelpers>;
-    expect(      $x->toString(),
-)->toBeSame(
-      '<div class="herp"><div class="derp"></div></div>'    );
+    expect($x->toString())->toBeSame(
+      '<div class="herp"><div class="derp"></div></div>',
+    );
   }
 }


### PR DESCRIPTION
hhast migrate + hackfmt

Also had to change the order of args (i.e. expect(a)->toBeSame(b) to expect(b)->toBeSame(a)) in two expect calls (tests/XHPHelpersTest.php, line 79 + 86) because they have side effects.