### PR TITLE
Ensure that special attributes should not render when null

### DIFF
--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -357,6 +357,9 @@ abstract class :x:composable-element extends :xhp {
         $value = $this->validateAttributeValue($attr, $value);
       }
     } else {
+      // Skip null values for special attributes instead of casting them to empty string,
+      // since null is used to conditionally remove the values
+      if ($value === null) return $this;
       $value = (string)$value;
     }
     $this->attributes->set($attr, $value);

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -357,10 +357,7 @@ abstract class :x:composable-element extends :xhp {
         $value = $this->validateAttributeValue($attr, $value);
       }
     } else {
-      // Skip null values for special attributes instead of casting them to empty string,
-      // since null is used to conditionally remove the values
-      if ($value === null) return $this;
-      $value = (string)$value;
+      $value = $value;
     }
     $this->attributes->set($attr, $value);
     return $this;

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -375,6 +375,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
     // verify that special attributes actually render
     $x = <div data-idonotexist="derp" />;
     expect($x->toString())->toBeSame('<div data-idonotexist="derp"></div>');
+    // implicit string cast
+    $x = <div data-idonotexist={123} />;
+    expect($x->toString())->toBeSame('<div data-idonotexist="123"></div>');
     $x = <div aria-idonotexist="derp" />;
     expect($x->toString())->toBeSame('<div aria-idonotexist="derp"></div>');
 

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -371,6 +371,18 @@ class AttributesTest extends Facebook\HackTest\HackTest {
     expect($x->toString())->toBeSame('<div>mydefault</div>');
     $x = <test:default-attributes aria-idonotexist="derp" />;
     expect($x->toString())->toBeSame('<div>mydefault</div>');
+
+    // verify that special attributes actually render
+    $x = <div data-idonotexist="derp" />;
+    expect($x->toString())->toBeSame('<div data-idonotexist="derp"></div>');
+    $x = <div aria-idonotexist="derp" />;
+    expect($x->toString())->toBeSame('<div aria-idonotexist="derp"></div>');
+
+    // special attributes should disappear when null, like all other attributes
+    $x = <div data-idonotexist={null} />;
+    expect($x->toString())->toBeSame('<div></div>');
+    $x = <div aria-idonotexist={null} />;
+    expect($x->toString())->toBeSame('<div></div>');
   }
 
   public function testRenderCallableAttribute(): void {

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -383,6 +383,10 @@ class AttributesTest extends Facebook\HackTest\HackTest {
     expect($x->toString())->toBeSame('<div></div>');
     $x = <div aria-idonotexist={null} />;
     expect($x->toString())->toBeSame('<div></div>');
+
+    $x = <div data-foo="derp" />;
+    $x->setAttribute('data-foo', null);
+    expect($x->toString())->toBeSame('<div></div>');
   }
 
   public function testRenderCallableAttribute(): void {


### PR DESCRIPTION
Previously, regular attributes are removed from the DOM when null, but
special attributes would be cast to empty string. This makes them behave
more like regular attributes, so that it's possible to use null as a sentinel
value to remove them from the DOM.

## Before

```
<div data-idonotexist={null} />;
```

would render as `<div data-idonotexist=""></div>;`

Unit tests show that now the attribute is removed when null
