### PR TITLE
Remove usages of lval as an expression.

### DIFF
--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -797,7 +797,8 @@ abstract class :x:composable-element extends :xhp {
     foreach ($this->children as $child) {
       if ($child instanceof :xhp) {
         $tmp = ':'.:xhp::class2element(get_class($child));
-        if ($categories = $child->__xhpCategoryDeclaration()) {
+        $categories = $child->__xhpCategoryDeclaration();
+        if (C\count($categories) > 0) {
           $tmp .= '[%'.implode(',%', array_keys($categories)).']';
         }
         $desc[] = $tmp;

--- a/src/html/XHPBaseHTMLHelpers.php
+++ b/src/html/XHPBaseHTMLHelpers.php
@@ -45,7 +45,8 @@ trait XHPBaseHTMLHelpers implements HasXHPBaseHTMLHelpers {
     $id = /* UNSAFE_EXPR */ $this->:id;
     if ($id === null || $id === '') {
       try {
-        $this->setAttribute('id', $id = bin2hex(random_bytes(5)));
+        $id = bin2hex(random_bytes(5));
+        $this->setAttribute('id', $id);
       } catch (XHPInvalidAttributeException $error) {
         throw new XHPException(
           'You are trying to add an HTML id to a(n) '.

--- a/src/html/XHPHelpers.php
+++ b/src/html/XHPHelpers.php
@@ -182,15 +182,15 @@ trait XHPHelpers implements HasXHPHelpers {
     foreach ($this->getAttributeNamesThatAppendValuesOnTransfer() as $attr) {
       if (array_key_exists($attr, $attributes)) {
         $rootAttributes = $root->getAttributes();
-        if (
-          array_key_exists($attr, $rootAttributes) &&
-          ($rootValue = (string)$rootAttributes[$attr]) !== ''
-        ) {
-          $thisValue = (string)$attributes[$attr];
-          if ($thisValue !== '') {
-            $root->setAttribute($attr, $rootValue.' '.$thisValue);
+        if (array_key_exists($attr, $rootAttributes)) {
+          $rootValue = (string)$rootAttributes[$attr];
+          if ($rootValue !== '') {
+            $thisValue = (string)$attributes[$attr];
+            if ($thisValue !== '') {
+              $root->setAttribute($attr, $rootValue.' '.$thisValue);
+            }
+            $this->removeAttribute($attr);
           }
-          $this->removeAttribute($attr);
         }
       }
     }


### PR DESCRIPTION
Summary: required for .hhconfig disable_lval_as_an_expression.

Signed-off-by: Arthur Loiret <arthur.loiret@emerton-data.com>