### PR TITLE
unbreak AsyncTest

### DIFF
--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -95,7 +95,8 @@ class AsyncTest extends Facebook\HackTest\HackTest {
 
   <<DataProvider('parallelizationContainersProvider')>>
   public function testParallelization(:x:element $container): void {
-    :async:par-test::$log = Vector {};
+    $par_test_classname = :async:par-test::class;
+    $par_test_classname::$log = Vector {};
 
     $a = <async:par-test label="a" />;
     $b = <async:par-test label="b" />;
@@ -108,7 +109,7 @@ class AsyncTest extends Facebook\HackTest\HackTest {
       '<div><div>a</div><div>b</div><div>c</div></div>',
     );
 
-    $log = :async:par-test::$log;
+    $log = $par_test_classname::$log;
     $by_node = Map { 'a' => Map {}, 'b' => Map {}, 'c' => Map {} };
 
     foreach ($log as $idx => $data) {


### PR DESCRIPTION
This is weird...as of the latest nightly, `:async:par-test::$log` results in a runtime error:

```
Class undefined: \:async:par-test
```

Probably a bug? This works around it but it would be better to fix it. Looking at the [commits that made it into the latest nightly](https://github.com/facebook/hhvm/commits/master?after=f88acfe5fc92d4c07b7c2148deec311b5044224c+0), I don't see any obvious cause...any ideas?