### PR TITLE
Remove runtime userland typechecks

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,5 +1,5 @@
 assume_php=false
-ignored_paths = [ "vendor/.+/tests/.+" ]
+ignored_paths = [ "vendor/.+/tests/.+", "vendor/bin/.+" ]
 disallow_elvis_space=true
 disallow_non_arraykey_keys=true
 disallow_unsafe_comparisons=true

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -517,7 +517,7 @@ abstract class :x:composable-element extends :xhp {
    * The fact that :xhp::enableAttributeValidation() enables these coersions
    * is misleading.
    */
-  final protected function validateEnumValuesAndCoerceScalars<T>(
+  final protected function validateEnumValuesAndCoerceScalars(
     string $attr,
     mixed $val,
   ): mixed {

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -514,7 +514,7 @@ abstract class :x:composable-element extends :xhp {
    * on this element and this type appears to be an enum.
    * If this type is a scalar however, we will coerce it to that type.
    * This is something from the past and should ideally not be relied upon.
-   * The fact that :xhp::enableAttributeValidation() enables these coersions
+   * The fact that :xhp::enableAttributeValidation() enables these coercions
    * is misleading.
    */
   final protected function validateEnumValuesAndCoerceScalars(
@@ -546,7 +546,7 @@ abstract class :x:composable-element extends :xhp {
         }
         break;
 
-      // Coersion should ideally not be relied on, but it is not causing trouble (yet)
+      // Coercion should ideally not be relied on, but it is not causing trouble (yet)
       case XHPAttributeType::TYPE_STRING:
         if (!($val is string)) {
           $val = XHPAttributeCoercion::CoerceToString($this, $attr, $val);

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -117,22 +117,22 @@ abstract class :x:composable-element extends :xhp {
     foreach ($children as $xhp) {
       /* HH_FIXME[4273] bogus "XHPChild always truthy" - FB T41388073 */
     if ($xhp is :x:frag) {
-      foreach ($xhp->children as $child) {
-        $new_children->add($child);
-      }
-    } else if (!($xhp is Traversable<_>)) {
-      $new_children->add($xhp);
-    } else {
-      foreach ($xhp as $element) {
-        if ($element is :x:frag) {
-          foreach ($element->children as $child) {
-            $new_children->add($child);
+        foreach ($xhp->children as $child) {
+          $new_children->add($child);
+        }
+      } else if (!($xhp is Traversable<_>)) {
+        $new_children->add($xhp);
+      } else {
+        foreach ($xhp as $element) {
+          if ($element is :x:frag) {
+            foreach ($element->children as $child) {
+              $new_children->add($child);
+            }
+          } else if ($element !== null) {
+            $new_children->add($element as XHPChild);
           }
-        } else if ($element !== null) {
-          $new_children->add($element as XHPChild);
         }
       }
-    }
     }
     $this->children = $new_children;
     return $this;
@@ -520,6 +520,7 @@ abstract class :x:composable-element extends :xhp {
    * Throws an exception if $val is not a valid value for the attribute $attr
    * on this element.
    */
+  <<__Deprecated('Runtime validation is going')>>
   final protected function validateAttributeValue<T>(
     string $attr,
     T $val,

--- a/src/core/ReflectionXHPAttribute.php
+++ b/src/core/ReflectionXHPAttribute.php
@@ -17,7 +17,6 @@ enum XHPAttributeType: int {
   TYPE_VAR = 6;
   TYPE_ENUM = 7;
   TYPE_FLOAT = 8;
-  TYPE_UNSUPPORTED_LEGACY_CALLABLE = 9;
 }
 
 class ReflectionXHPAttribute {
@@ -31,7 +30,7 @@ class ReflectionXHPAttribute {
   private mixed $defaultValue;
   private bool $required;
 
-  private static ImmSet<string> $specialAttributes = ImmSet { 'data', 'aria' };
+  private static ImmSet<string> $specialAttributes = ImmSet {'data', 'aria'};
 
   public function __construct(private string $name, array<int, mixed> $decl) {
     $this->type = XHPAttributeType::assert($decl[0]);
@@ -133,9 +132,6 @@ class ReflectionXHPAttribute {
         break;
       case XHPAttributeType::TYPE_FLOAT:
         $out = 'float';
-        break;
-      case XHPAttributeType::TYPE_UNSUPPORTED_LEGACY_CALLABLE:
-        $out = '<UNSUPPORTED: legacy callable>';
         break;
     }
     $out .= ' '.$this->getName();

--- a/src/core/XHP.php
+++ b/src/core/XHP.php
@@ -72,6 +72,11 @@ abstract class :xhp implements XHPChild, JsonSerializable {
     self::$validateAttributes = false;
   }
 
+  <<__Deprecated(
+    'The validation rules have been changed.'.
+    'They will now only apply for enums (both Hack and XHP enums).'.
+    'This funcionality will be remove completely at some point.',
+  )>>
   public static function enableAttributeValidation(): void {
     self::$validateAttributes = true;
   }

--- a/src/core/XHP.php
+++ b/src/core/XHP.php
@@ -76,7 +76,6 @@ abstract class :xhp implements XHPChild, JsonSerializable {
     self::$validateAttributes = true;
   }
 
-  <<__Deprecated('Runtime validation is going')>>
   public static function isAttributeValidationEnabled(): bool {
     return self::$validateAttributes;
   }

--- a/src/core/XHP.php
+++ b/src/core/XHP.php
@@ -76,6 +76,7 @@ abstract class :xhp implements XHPChild, JsonSerializable {
     self::$validateAttributes = true;
   }
 
+  <<__Deprecated('Runtime validation is going')>>
   public static function isAttributeValidationEnabled(): bool {
     return self::$validateAttributes;
   }

--- a/tests/AttributesCoercionModeTest.php
+++ b/tests/AttributesCoercionModeTest.php
@@ -31,6 +31,7 @@ class AttributesCoercionModeTest extends Facebook\HackTest\HackTest {
   public async function beforeEachTestAsync(): Awaitable<void> {
     $this->coercionMode = XHPAttributeCoercion::GetMode();
     $this->errorReporting = error_reporting();
+    /*HH_FIXME[4128] Deprecated, because we are trying to remove this.*/
     :xhp::enableAttributeValidation();
   }
 

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -68,6 +68,7 @@ class StringableTestClass {
 class AttributesTest extends Facebook\HackTest\HackTest {
   public async function beforeEachTestAsync(): Awaitable<void> {
     XHPAttributeCoercion::SetMode(XHPAttributeCoercionMode::SILENT);
+    /*HH_FIXME[4128] Deprecated, because we are trying to remove this.*/
     :xhp::enableAttributeValidation();
   }
 

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -93,6 +93,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testShapeWithExtraKey(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
     expect(() ==> {
 
       $x =
@@ -107,6 +108,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testShapeWithMissingOptionalKey(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
     expect(() ==> {
 
       /* HH_IGNORE_ERROR[4057] */
@@ -116,6 +118,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testShapeWithMissingRequiredKey(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
     expect(() ==> {
       /* HH_IGNORE_ERROR[4057] */
       $x = <test:attribute-types myshape={shape()} />;
@@ -130,6 +133,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testInvalidArrayKeys(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -147,6 +151,8 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testInvalidNum(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
+
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -327,6 +333,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testNotAContainerAsArray(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -338,6 +345,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testHackContainerAsArray(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -347,6 +355,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testIncompatibleObjectAsObject(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -358,6 +367,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testPassingArrayAsVector(): void {
+    self::markTestSkipped('Only enums are validated at runtime.');
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -424,6 +434,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testRenderCallableAttribute(): void {
+    self::markTestSkipped('This type has been unsupported since 2.0');
     expect(() ==> {
       $x =
         <test:callable-attribute
@@ -436,6 +447,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testReflectOnCallableAttribute(): void {
+    self::markTestSkipped('This type has been unsupported since 2.0');
     $rxhp = new ReflectionXHPClass(:test:callable-attribute::class);
     $rattr = $rxhp->getAttribute('foo');
     expect(

--- a/tests/HackEnumAttributesTest.php
+++ b/tests/HackEnumAttributesTest.php
@@ -25,6 +25,7 @@ class :test:hack-enum-attribute extends :x:element {
 
 class HackEnumAttributesTest extends Facebook\HackTest\HackTest {
   public async function beforeEachTestAsync(): Awaitable<void> {
+    /*HH_FIXME[4128] Deprecated, because we are trying to remove this.*/
     :xhp::enableAttributeValidation();
   }
 


### PR DESCRIPTION
# My reasons

Runtime type validation on XHP properties has been broken for a while. I tried fixing Stringish validation a little while ago, but that was just the first type that had false negatives. `\HH\vec<T>` is not an `\HH\Traversable<T>` according to XHP. There has been discussion about removing the runtime validation all since before I even knew about Hack. It just appears that no one wanted to tackle it, since it was just disabled by default at some point.

# Rationale

My goal was to eliminate false negatives as much as possible. I first removed all runtime typechecking, however, I quickly noticed however that XHP enums are not covered by the typechecker. So, in order to make those attribute types have some value, I kept enum validation for XHP enums. This ended up making XHP enums stronger than Hack enums and we don't want that. We want to encourage the use of Hack enums, since they are typechecked. So in order to not create confusion between the two enum types, I kept validation on both.

Strangely validation also gates coercion features. I can't imagine people using it, since enabling validation has runtime exceptions on false positives. But if you were relying on that, I haven't stripped it out.