### PR TITLE
RFC/Proof-of-concept: Implement children declarations as a trait

### DIFF
--- a/src/children/Any.hack
+++ b/src/children/Any.hack
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+final class Any implements Constraint {
+  public function legacySerialize(): mixed {
+    return 1;
+  }
+
+  public function legacySerializeAsLeaf(): (LegacyConstraintType, mixed) {
+    return tuple(LegacyConstraintType::ANY, null);
+  }
+}

--- a/src/children/AnyNumberOf.hack
+++ b/src/children/AnyNumberOf.hack
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+final class AnyNumberOf<T as Constraint> extends QuantifierConstraint<T> {
+  const LegacyExpressionType LEGACY_EXPRESSION_TYPE =
+    LegacyExpressionType::ANY_QUANTITY;
+}

--- a/src/children/AnyOf.hack
+++ b/src/children/AnyOf.hack
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+use namespace HH\Lib\{C, Vec};
+
+final class AnyOf<T as Constraint> implements LegacyExpression {
+  private vec<T> $children;
+  public function __construct(T $a, T $b, T ...$rest) {
+    $this->children = Vec\concat(vec[$a, $b], $rest);
+  }
+
+  public function legacySerialize(): (LegacyExpressionType, mixed, mixed) {
+    $it = tuple(
+      LegacyExpressionType::EITHER,
+      $this->children[0]->legacySerialize(),
+      $this->children[1]->legacySerialize(),
+    );
+    $rest = Vec\drop($this->children, 2);
+    while (!C\is_empty($rest)) {
+      $it = tuple(
+        LegacyExpressionType::EITHER,
+        $it,
+        $rest[0]->legacySerialize(),
+      );
+      $rest = Vec\drop($rest, 1);
+    }
+    return $it;
+  }
+
+  final public function legacySerializeAsLeaf(): null {
+    return null;
+  }
+}

--- a/src/children/AtLeastOneOf.hack
+++ b/src/children/AtLeastOneOf.hack
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+final class AtLeastOneOf<T as Constraint> extends QuantifierConstraint<T> {
+  const LegacyExpressionType LEGACY_EXPRESSION_TYPE =
+    LegacyExpressionType::AT_LEAST_ONE;
+}

--- a/src/children/Category.hack
+++ b/src/children/Category.hack
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+use namespace HH\Lib\Str;
+
+final class Category extends LeafConstraint {
+  public function __construct(private string $category) {
+  }
+
+  public function legacySerializeAsLeaf(): (LegacyConstraintType, string) {
+    return tuple(
+      LegacyConstraintType::CATEGORY,
+      $this->category
+        |> Str\strip_prefix($$, '%')
+        |> Str\replace($$, ':', '__')
+        |> Str\replace($$, '-', '_'),
+    );
+  }
+}

--- a/src/children/Constraint.hack
+++ b/src/children/Constraint.hack
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+interface Constraint {
+  public function legacySerialize(): mixed;
+  public function legacySerializeAsLeaf(): ?(LegacyConstraintType, mixed);
+}

--- a/src/children/LeafConstraint.hack
+++ b/src/children/LeafConstraint.hack
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+abstract class LeafConstraint implements LegacyExpression {
+  abstract public function legacySerializeAsLeaf(
+  ): (LegacyConstraintType, mixed);
+
+  final public function legacySerialize(
+  ): (LegacyExpressionType, LegacyConstraintType, mixed) {
+    $as_leaf = $this->legacySerializeAsLeaf();
+    return tuple(LegacyExpressionType::EXACTLY_ONE, $as_leaf[0], $as_leaf[1]);
+  }
+}

--- a/src/children/LegacyConstraintType.hack
+++ b/src/children/LegacyConstraintType.hack
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+enum LegacyConstraintType: int {
+  ANY = 1;
+  PCDATA = 2;
+  CLASSNAME = 3;
+  CATEGORY = 4;
+  EXPRESSION = 5;
+}

--- a/src/children/LegacyExpression.hack
+++ b/src/children/LegacyExpression.hack
@@ -1,0 +1,14 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+interface LegacyExpression extends Constraint {
+  public function legacySerialize(): (LegacyExpressionType, mixed, mixed);
+}

--- a/src/children/LegacyExpressionType.hack
+++ b/src/children/LegacyExpressionType.hack
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+enum LegacyExpressionType: int {
+  EXACTLY_ONE = 0;
+  ANY_QUANTITY = 1;
+  ZERO_OR_ONE = 2;
+  AT_LEAST_ONE = 3;
+  SEQUENCE = 4;
+  EITHER = 5;
+}

--- a/src/children/None.hack
+++ b/src/children/None.hack
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+final class None implements Constraint {
+  public function legacySerialize(): mixed {
+    return 0;
+  }
+
+  public function legacySerializeAsLeaf(): null {
+    return null;
+  }
+}

--- a/src/children/OfType.hack
+++ b/src/children/OfType.hack
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+final class OfType<<<__Enforceable>> reify T> extends LeafConstraint {
+  public function legacySerializeAsLeaf(): (LegacyConstraintType, string) {
+    return tuple(
+      LegacyConstraintType::CLASSNAME,
+      \HH\ReifiedGenerics\get_classname<T>(),
+    );
+  }
+}

--- a/src/children/Optional.hack
+++ b/src/children/Optional.hack
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+final class Optional<T as Constraint> extends QuantifierConstraint<T> {
+  const LegacyExpressionType LEGACY_EXPRESSION_TYPE =
+    LegacyExpressionType::ZERO_OR_ONE;
+}

--- a/src/children/PCData.hack
+++ b/src/children/PCData.hack
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+final class PCData extends LeafConstraint {
+  public function legacySerializeAsLeaf(): (LegacyConstraintType, mixed) {
+    return tuple(LegacyConstraintType::PCDATA, null);
+  }
+}

--- a/src/children/QuantifierConstraint.hack
+++ b/src/children/QuantifierConstraint.hack
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+abstract class QuantifierConstraint<T as Constraint>
+  implements LegacyExpression {
+  abstract const LegacyExpressionType LEGACY_EXPRESSION_TYPE;
+
+  final public function __construct(private T $child) {}
+
+  final public function legacySerialize(
+  ): (LegacyExpressionType, mixed, mixed) {
+    $inner = $this->child;
+    $as_leaf = $inner->legacySerializeAsLeaf();
+    if ($as_leaf is nonnull) {
+      return tuple(static::LEGACY_EXPRESSION_TYPE, $as_leaf[0], $as_leaf[1]);
+    }
+
+    return tuple(
+      static::LEGACY_EXPRESSION_TYPE,
+      LegacyConstraintType::EXPRESSION,
+      $inner->legacySerialize(),
+    );
+  }
+
+  final public function legacySerializeAsLeaf(): null {
+    return null;
+  }
+}

--- a/src/children/Sequence.hack
+++ b/src/children/Sequence.hack
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+use namespace HH\Lib\{C, Vec};
+
+final class Sequence<T as Constraint> implements LegacyExpression {
+  private vec<T> $children;
+
+  public function __construct(T $a, T $b, T ...$rest) {
+    $this->children = Vec\concat(vec[$a, $b], $rest);
+  }
+
+  public function legacySerialize(): (LegacyExpressionType, mixed, mixed) {
+    $it = tuple(
+      LegacyExpressionType::SEQUENCE,
+      $this->children[0]->legacySerialize(),
+      $this->children[1]->legacySerialize(),
+    );
+    $rest = Vec\drop($this->children, 2);
+    while (!C\is_empty($rest)) {
+      $it = tuple(
+        LegacyExpressionType::SEQUENCE,
+        $it,
+        $rest[0]->legacySerialize(),
+      );
+      $rest = Vec\drop($rest, 1);
+    }
+    return $it;
+  }
+
+  public function legacySerializeAsLeaf(): null {
+    return null;
+  }
+}

--- a/src/children/XHPChildDeclarationConsistencyTrait.hack
+++ b/src/children/XHPChildDeclarationConsistencyTrait.hack
@@ -13,11 +13,9 @@ use namespace \Facebook\XHP\ChildValidation as XHPChild;
 trait XHPChildDeclarationConsistencyTrait {
   require extends :x:element;
 
-  abstract protected function getChildrenDeclaration(): XHPChild\Constraint;
+  abstract protected static function getChildrenDeclaration(): XHPChild\Constraint;
 
   final private static function normalize(mixed $x): mixed {
-    // (exactly one, expr, $x) is equivalent to $x; HackC
-    // always generates this form for the top-level constraint
     if (
       $x is (int, int, mixed) &&
       $x[0] === XHPChild\LegacyExpressionType::EXACTLY_ONE &&
@@ -35,7 +33,7 @@ trait XHPChildDeclarationConsistencyTrait {
 
   final public function validateChildren(): void {
     $old = self::normalize($this->__xhpChildrenDeclaration());
-    $new = self::normalize($this->getChildrenDeclaration()->legacySerialize());
+    $new = self::normalize(static::getChildrenDeclaration()->legacySerialize());
 
     invariant(
       $old === $new,
@@ -43,7 +41,7 @@ trait XHPChildDeclarationConsistencyTrait {
       static::class,
       \var_export($old, true),
       \var_export($new, true),
-      \var_export($this->getChildrenDeclaration(), true),
+      \var_export(static::getChildrenDeclaration(), true),
     );
     parent::validateChildren();
   }

--- a/src/children/XHPChildDeclarationConsistencyTrait.hack
+++ b/src/children/XHPChildDeclarationConsistencyTrait.hack
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace \Facebook\XHP\ChildValidation as XHPChild;
+
+/** Verify that a new child declaration matches the legacy codegen. */
+trait XHPChildDeclarationConsistencyTrait {
+  require extends :x:element;
+
+  abstract protected function getChildrenDeclaration(): XHPChild\Constraint;
+
+  final private static function normalize(mixed $x): mixed {
+    // (exactly one, expr, $x) is equivalent to $x; HackC
+    // always generates this form for the top-level constraint
+    if (
+      $x is (int, int, mixed) &&
+      $x[0] === XHPChild\LegacyExpressionType::EXACTLY_ONE &&
+      $x[1] === XHPChild\LegacyConstraintType::EXPRESSION
+    ) {
+      return self::normalize($x[2]);
+    }
+
+    if ($x is (int, mixed, mixed)) {
+      return tuple($x[0], self::normalize($x[1]), self::normalize($x[2]));
+    }
+
+    return $x;
+  }
+
+  final public function validateChildren(): void {
+    $old = self::normalize($this->__xhpChildrenDeclaration());
+    $new = self::normalize($this->getChildrenDeclaration()->legacySerialize());
+
+    invariant(
+      $old === $new,
+      "Old and new XHP children declarations differ in class %s.\nOld\n---\n\n%s\n\nNew\n---\n\n%s\n---\n\n%s",
+      static::class,
+      \var_export($old, true),
+      \var_export($new, true),
+      \var_export($this->getChildrenDeclaration(), true),
+    );
+    parent::validateChildren();
+  }
+}

--- a/src/children/XHPChildDeclarationConsistencyValidation.hack
+++ b/src/children/XHPChildDeclarationConsistencyValidation.hack
@@ -10,10 +10,11 @@
 use namespace \Facebook\XHP\ChildValidation as XHPChild;
 
 /** Verify that a new child declaration matches the legacy codegen. */
-trait XHPChildDeclarationConsistencyTrait {
+trait XHPChildDeclarationConsistencyValidation {
   require extends :x:element;
 
-  abstract protected static function getChildrenDeclaration(): XHPChild\Constraint;
+  abstract protected static function getChildrenDeclaration(
+  ): XHPChild\Constraint;
 
   final private static function normalize(mixed $x): mixed {
     if (

--- a/src/children/XHPChildValidation.hack
+++ b/src/children/XHPChildValidation.hack
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace \Facebook\XHP\ChildValidation as XHPChild;
+
+/** Verify that a new child declaration matches the legacy codegen. */
+trait XHPChildValidation {
+  require extends :x:element;
+
+  abstract protected static function getChildrenDeclaration(
+  ): XHPChild\Constraint;
+
+  <<__Override>>
+  final protected static function __legacySerializedXHPChildrenDeclaration(
+  ): mixed {
+    return static::getChildrenDeclaration()->legacySerialize();
+  }
+
+  final public function validateChildren(): void {
+    invariant(
+      $this->__xhpChildrenDeclaration() ===
+        :x:element::__NO_LEGACY_CHILDREN_DECLARATION,
+      "The XHPChildValidation trait can not be used with a 'children' ".
+      "declaration; override 'getChildrenDeclaration()'' instead",
+    );
+
+    parent::validateChildren();
+  }
+}

--- a/src/children/functions.hack
+++ b/src/children/functions.hack
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\ChildValidation;
+
+<<__Memoize>>
+function any(): Any {
+  return new Any();
+}
+
+function anyNumberOf<T as Constraint>(T $a): AnyNumberOf<T> {
+  return new AnyNumberOf($a);
+}
+
+function anyOf<T as Constraint>(T $a, T $b, T ...$rest): AnyOf<T> {
+  return new AnyOf($a, $b, ...$rest);
+}
+
+function atLeastOneOf<T as Constraint>(T $a): AtLeastOneOf<T> {
+  return new AtLeastOneOf($a);
+}
+
+<<__Memoize>>
+function category(string $c): Category {
+  return new Category($c);
+}
+
+<<__Memoize>>
+function empty(): None {
+  return new None();
+}
+
+function ofType<<<__Enforceable>> reify T>(): OfType<T> {
+  return new OfType<T>();
+}
+
+function optional<T as Constraint>(T $a): Optional<T> {
+  return new Optional($a);
+}
+
+function pcdata(): PCData {
+  return new PCData();
+}
+
+function sequence<T as Constraint>(T $a, T $b, T ...$rest): Sequence<T> {
+  return new Sequence($a, $b, ...$rest);
+}

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -580,7 +580,7 @@ abstract class :x:composable-element extends :xhp {
    * Validates that this element's children match its children descriptor, and
    * throws an exception if that's not the case.
    */
-  final protected function validateChildren(): void {
+  protected function validateChildren(): void {
     $decl = self::__xhpReflectionChildrenDeclaration();
     $type = $decl->getType();
     if ($type === XHPChildrenDeclarationType::ANY_CHILDREN) {

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -270,12 +270,20 @@ abstract class :x:composable-element extends :xhp {
     return $map;
   }
 
+  protected static function __legacySerializedXHPChildrenDeclaration(): mixed {
+    $decl = self::emptyInstance()->__xhpChildrenDeclaration();
+    if ($decl === self::__NO_LEGACY_CHILDREN_DECLARATION) {
+      return 1; // any children
+    }
+    return $decl;
+  }
+
   <<__MemoizeLSB>>
   final public static function __xhpReflectionChildrenDeclaration(
   ): ReflectionXHPChildrenDeclaration {
     return new ReflectionXHPChildrenDeclaration(
       :xhp::class2element(static::class),
-      self::emptyInstance()->__xhpChildrenDeclaration(),
+      static::__legacySerializedXHPChildrenDeclaration(),
     );
   }
 
@@ -498,6 +506,8 @@ abstract class :x:composable-element extends :xhp {
     return darray[];
   }
 
+  const int __NO_LEGACY_CHILDREN_DECLARATION = -31337;
+
   /**
    * Defined in elements by the `children` keyword. This returns a pattern of
    * allowed children. The return value is potentially very complicated. The
@@ -506,7 +516,7 @@ abstract class :x:composable-element extends :xhp {
    * biggest mess you've ever seen.
    */
   protected function __xhpChildrenDeclaration(): mixed {
-    return 1;
+    return self::__NO_LEGACY_CHILDREN_DECLARATION;
   }
 
   /**

--- a/tests/ChildRuleTest.php
+++ b/tests/ChildRuleTest.php
@@ -12,8 +12,42 @@ use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
+class :test:new-child-declaration-only extends :x:element {
+  use XHPChildValidation;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\ofType<:div>();
+  }
+
+  protected function render(): XHPRoot {
+    return <x:frag>{$this->getChildren()}</x:frag>;
+  }
+}
+
+class :test:new-and-old-child-declarations extends :x:element {
+  // Providing all of these is invalid; for a migration consistency check, use
+  // the XHPChildDeclarationConsistencyValidation trait instead.
+  use XHPChildValidation;
+  children (:div);
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\ofType<:div>();
+  }
+
+  protected function render(): XHPRoot {
+    return <div />;
+  }
+}
+
+class :test:old-child-declaration-only extends :x:element {
+  children (:div);
+
+  protected function render(): XHPRoot {
+    return <x:frag>{$this->getChildren()}</x:frag>;
+  }
+}
+
 class :test:any-children extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children any;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any();
@@ -25,7 +59,7 @@ class :test:any-children extends :x:element {
 }
 
 class :test:no-children extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children empty;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\empty();
@@ -37,7 +71,7 @@ class :test:no-children extends :x:element {
 }
 
 class :test:single-child extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\ofType<:div>();
@@ -49,7 +83,7 @@ class :test:single-child extends :x:element {
 }
 
 class :test:optional-child extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div?);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\optional(XHPChild\ofType<:div>());
@@ -60,9 +94,8 @@ class :test:optional-child extends :x:element {
   }
 }
 
-
 class :test:any-number-of-child extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div*);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyNumberOf(XHPChild\ofType<:div>());
@@ -74,7 +107,7 @@ class :test:any-number-of-child extends :x:element {
 }
 
 class :test:at-least-one-child extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div+);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\atLeastOneOf(XHPChild\ofType<:div>());
@@ -86,7 +119,7 @@ class :test:at-least-one-child extends :x:element {
 }
 
 class :test:two-children extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div, :div);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(XHPChild\ofType<:div>(), XHPChild\ofType<:div>());
@@ -98,7 +131,7 @@ class :test:two-children extends :x:element {
 }
 
 class :test:three-children extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div, :div, :div);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(
@@ -115,7 +148,7 @@ class :test:three-children extends :x:element {
 
 
 class :test:either-of-two-children extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div | :code);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(XHPChild\ofType<:div>(), XHPChild\ofType<:code>());
@@ -127,7 +160,7 @@ class :test:either-of-two-children extends :x:element {
 }
 
 class :test:any-of-three-children extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div | :code | :p);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(
@@ -144,7 +177,7 @@ class :test:any-of-three-children extends :x:element {
 
 
 class :test:nested-rule extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (:div | (:code+));
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(
@@ -159,7 +192,7 @@ class :test:nested-rule extends :x:element {
 }
 
 class :test:pcdata-child extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\pcdata();
@@ -171,7 +204,7 @@ class :test:pcdata-child extends :x:element {
 }
 
 class :test:category-child extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (%flow);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%flow');
@@ -183,7 +216,7 @@ class :test:category-child extends :x:element {
 }
 
 class :test:has-comma-category extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   category %foo:bar;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%foo:bar');
@@ -195,7 +228,7 @@ class :test:has-comma-category extends :x:element {
 }
 
 class :test:needs-comma-category extends :x:element {
-  use XHPChildDeclarationConsistencyTrait;
+  use XHPChildDeclarationConsistencyValidation;
   children (%foo:bar);
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%foo:bar');
@@ -393,5 +426,49 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       $x = <div><test:at-least-one-child /></div>;
       $x->toString();
     })->toThrow(XHPInvalidChildrenException::class);
+  }
+
+  public function testNewChildDeclarations(): void {
+    expect(
+      (
+        <test:new-child-declaration-only>
+          <div>foo</div>
+        </test:new-child-declaration-only>
+      )->toString(),
+    )->toEqual('<div>foo</div>');
+
+    expect(() ==> (<test:new-child-declaration-only />)->toString())->toThrow(
+      XHPInvalidChildrenException::class,
+    );
+    expect(
+      () ==> (
+        <test:new-child-declaration-only><p /></test:new-child-declaration-only>
+      )->toString(),
+    )->toThrow(XHPInvalidChildrenException::class);
+  }
+
+  public function testOldChildDeclarations(): void {
+    expect(
+      (
+        <test:old-child-declaration-only>
+          <div>foo</div>
+        </test:old-child-declaration-only>
+      )->toString(),
+    )->toEqual('<div>foo</div>');
+
+    expect(() ==> (<test:old-child-declaration-only />)->toString())->toThrow(
+      XHPInvalidChildrenException::class,
+    );
+    expect(
+      () ==> (
+        <test:old-child-declaration-only><p /></test:old-child-declaration-only>
+      )->toString(),
+    )->toThrow(XHPInvalidChildrenException::class);
+  }
+
+
+  public function testConflictingNewAndOldChildDeclarations(): void {
+    expect(() ==> (<test:new-and-old-child-declarations />)->toString())
+      ->toThrow(InvariantException::class);
   }
 }

--- a/tests/ChildRuleTest.php
+++ b/tests/ChildRuleTest.php
@@ -15,7 +15,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 class :test:any-children extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children any;
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any();
   }
 
@@ -27,7 +27,7 @@ class :test:any-children extends :x:element {
 class :test:no-children extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children empty;
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\empty();
   }
 
@@ -39,7 +39,7 @@ class :test:no-children extends :x:element {
 class :test:single-child extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\ofType<:div>();
   }
 
@@ -51,7 +51,7 @@ class :test:single-child extends :x:element {
 class :test:optional-child extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div?);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\optional(XHPChild\ofType<:div>());
   }
 
@@ -64,7 +64,7 @@ class :test:optional-child extends :x:element {
 class :test:any-number-of-child extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div*);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyNumberOf(XHPChild\ofType<:div>());
   }
 
@@ -76,7 +76,7 @@ class :test:any-number-of-child extends :x:element {
 class :test:at-least-one-child extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div+);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\atLeastOneOf(XHPChild\ofType<:div>());
   }
 
@@ -88,7 +88,7 @@ class :test:at-least-one-child extends :x:element {
 class :test:two-children extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div, :div);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(XHPChild\ofType<:div>(), XHPChild\ofType<:div>());
   }
 
@@ -100,7 +100,7 @@ class :test:two-children extends :x:element {
 class :test:three-children extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div, :div, :div);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(
       XHPChild\ofType<:div>(),
       XHPChild\ofType<:div>(),
@@ -117,7 +117,7 @@ class :test:three-children extends :x:element {
 class :test:either-of-two-children extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div | :code);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(XHPChild\ofType<:div>(), XHPChild\ofType<:code>());
   }
 
@@ -129,7 +129,7 @@ class :test:either-of-two-children extends :x:element {
 class :test:any-of-three-children extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div | :code | :p);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(
       XHPChild\ofType<:div>(),
       XHPChild\ofType<:code>(),
@@ -146,7 +146,7 @@ class :test:any-of-three-children extends :x:element {
 class :test:nested-rule extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (:div | (:code+));
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(
       XHPChild\ofType<:div>(),
       XHPChild\atLeastOneOf(XHPChild\ofType<:code>()),
@@ -161,7 +161,7 @@ class :test:nested-rule extends :x:element {
 class :test:pcdata-child extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (pcdata);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\pcdata();
   }
 
@@ -173,7 +173,7 @@ class :test:pcdata-child extends :x:element {
 class :test:category-child extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (%flow);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%flow');
   }
 
@@ -185,7 +185,7 @@ class :test:category-child extends :x:element {
 class :test:has-comma-category extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   category %foo:bar;
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%foo:bar');
   }
 
@@ -197,7 +197,7 @@ class :test:has-comma-category extends :x:element {
 class :test:needs-comma-category extends :x:element {
   use XHPChildDeclarationConsistencyTrait;
   children (%foo:bar);
-  protected function getChildrenDeclaration(): XHPChild\Constraint {
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%foo:bar');
   }
 

--- a/tests/ChildRuleTest.php
+++ b/tests/ChildRuleTest.php
@@ -10,30 +10,51 @@
 
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 class :test:any-children extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children any;
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\any();
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
 }
 
 class :test:no-children extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children empty;
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\empty();
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
 }
 
 class :test:single-child extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (:div);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\ofType<:div>();
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
 }
 
 class :test:optional-child extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (:div?);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\optional(XHPChild\ofType<:div>());
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
@@ -41,42 +62,108 @@ class :test:optional-child extends :x:element {
 
 
 class :test:any-number-of-child extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (:div*);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\ofType<:div>());
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
 }
 
 class :test:at-least-one-child extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (:div+);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\atLeastOneOf(XHPChild\ofType<:div>());
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
 }
 
 class :test:two-children extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (:div, :div);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(XHPChild\ofType<:div>(), XHPChild\ofType<:div>());
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
 }
+
+class :test:three-children extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
+  children (:div, :div, :div);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\ofType<:div>(),
+      XHPChild\ofType<:div>(),
+      XHPChild\ofType<:div>(),
+    );
+  }
+
+  protected function render(): XHPRoot {
+    return <div />;
+  }
+}
+
 
 class :test:either-of-two-children extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (:div | :code);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyOf(XHPChild\ofType<:div>(), XHPChild\ofType<:code>());
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
 }
 
+class :test:any-of-three-children extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
+  children (:div | :code | :p);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyOf(
+      XHPChild\ofType<:div>(),
+      XHPChild\ofType<:code>(),
+      XHPChild\ofType<:p>(),
+    );
+  }
+
+  protected function render(): XHPRoot {
+    return <div />;
+  }
+}
+
+
 class :test:nested-rule extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (:div | (:code+));
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyOf(
+      XHPChild\ofType<:div>(),
+      XHPChild\atLeastOneOf(XHPChild\ofType<:code>()),
+    );
+  }
+
   protected function render(): XHPRoot {
     return <div />;
   }
 }
 
 class :test:pcdata-child extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (pcdata);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\pcdata();
+  }
 
   protected function render(): XHPRoot {
     return <div>{$this->getChildren()}</div>;
@@ -84,7 +171,11 @@ class :test:pcdata-child extends :x:element {
 }
 
 class :test:category-child extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (%flow);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\category('%flow');
+  }
 
   protected function render(): XHPRoot {
     return <div />;
@@ -92,7 +183,11 @@ class :test:category-child extends :x:element {
 }
 
 class :test:has-comma-category extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   category %foo:bar;
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\category('%foo:bar');
+  }
 
   protected function render(): XHPRoot {
     return <div />;
@@ -100,7 +195,11 @@ class :test:has-comma-category extends :x:element {
 }
 
 class :test:needs-comma-category extends :x:element {
+  use XHPChildDeclarationConsistencyTrait;
   children (%foo:bar);
+  protected function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\category('%foo:bar');
+  }
 
   protected function render(): XHPRoot {
     return <div />;
@@ -135,6 +234,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       <test:any-number-of-child />,
       <test:at-least-one-child />,
       <test:either-of-two-children />,
+      <test:any-of-three-children />,
       <test:nested-rule />,
       <test:category-child />,
     };
@@ -161,7 +261,9 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       tuple(<test:any-number-of-child />, '(:div*)'),
       tuple(<test:at-least-one-child />, '(:div+)'),
       tuple(<test:two-children />, '(:div,:div)'),
+      tuple(<test:three-children />, '(:div,:div,:div)'),
       tuple(<test:either-of-two-children />, '(:div|:code)'),
+      tuple(<test:any-of-three-children />, '(:div|:code|:p)'),
       tuple(<test:nested-rule />, '(:div|(:code+))'),
       tuple(<test:pcdata-child />, '(pcdata)'),
       tuple(<test:category-child />, '(%flow)'),
@@ -192,13 +294,14 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       <test:single-child />,
       <test:optional-child />,
       <test:two-children />,
+      <test:three-children />,
       <test:either-of-two-children />,
       <test:nested-rule />,
       <test:category-child />,
     };
     foreach ($elems as $elem) {
       $exception = null;
-      $elem->appendChild(<x:frag><div /><div /><div /></x:frag>);
+      $elem->appendChild(<x:frag><div /><div /><div /><div /></x:frag>);
       try {
         $elem->toString();
       } catch (Exception $e) {
@@ -215,6 +318,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       <test:any-number-of-child />,
       <test:at-least-one-child />,
       <test:either-of-two-children />,
+      <test:any-of-three-children />,
       <test:nested-rule />,
       <test:category-child />,
     };

--- a/tests/ChildRuleTest.php
+++ b/tests/ChildRuleTest.php
@@ -216,11 +216,7 @@ class :test:category-child extends :x:element {
 }
 
 class :test:has-comma-category extends :x:element {
-  use XHPChildDeclarationConsistencyValidation;
   category %foo:bar;
-  protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\category('%foo:bar');
-  }
 
   protected function render(): XHPRoot {
     return <div />;


### PR DESCRIPTION
Currently serializes to the same format as HackC, to allow migrating to
the new syntax with no changes to validation.

Some normalization is needed, as HackC emits some overly-complex
structures - e.g. with `$expr = tuple(EXACTLY_ONE, EXPRESSION, $inner_expr)`
can be simplified to `$expr = $inner_expr`.

It is not currently in a form suitable for use - the trait I've added
merely confirms that the two forms of children declaration are
semanticaly equivalent.

I think that's a meaningful first step; if we're happy for this, we can
merge it, start on migration tools, then add an alternative trait to
allow removal of the legacy syntax.

This is very much a draft API; open to a complete rewrite if desired :)

refs #212