### PR TITLE
Child validation: support `x:composable-element`, not just `x:element`

### DIFF
--- a/src/children/XHPChildDeclarationConsistencyValidation.hack
+++ b/src/children/XHPChildDeclarationConsistencyValidation.hack
@@ -11,7 +11,7 @@ use namespace \Facebook\XHP\ChildValidation as XHPChild;
 
 /** Verify that a new child declaration matches the legacy codegen. */
 trait XHPChildDeclarationConsistencyValidation {
-  require extends :x:element;
+  require extends :x:composable-element;
 
   abstract protected static function getChildrenDeclaration(
   ): XHPChild\Constraint;

--- a/src/children/XHPChildValidation.hack
+++ b/src/children/XHPChildValidation.hack
@@ -11,7 +11,7 @@ use namespace \Facebook\XHP\ChildValidation as XHPChild;
 
 /** Verify that a new child declaration matches the legacy codegen. */
 trait XHPChildValidation {
-  require extends :x:element;
+  require extends :x:composable-element;
 
   abstract protected static function getChildrenDeclaration(
   ): XHPChild\Constraint;


### PR DESCRIPTION
This makes it possible to use these traits for HTML tags etc

Test plan:

```
fredemmott@fredemmott-mm1 xhp-lib % ~/code/hhast/bin/hhast-migrate --add-xhp-children-declaration-method src
fredemmott@fredemmott-mm1 xhp-lib % hh_client
No errors!
fredemmott@fredemmott-mm1 xhp-lib % vendor/bin/hacktest tests
...............................................................................S.SSS.S.S.....................SSSS......SS....

Summary: 125 test(s), 113 passed, 0 failed, 12 skipped, 0 error(s).
fredemmott@fredemmott-mm1 xhp-lib % git diff src | gist  -t patch
https://gist.github.com/6dafcf73169756cc80078d2e765ada2c
```

Typechecker fails without this change, as basic HTML elements do not extend `:x:element`

That is with https://github.com/hhvm/hhast/pull/268