### PR TITLE
Add new child declaration methods

### DIFF
--- a/src/html/PcdataElement.php
+++ b/src/html/PcdataElement.php
@@ -11,6 +11,14 @@
 /**
  * Subclasses of :xhp:pcdata-elements may contain only string children.
  */
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 abstract class :xhp:pcdata-element extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\pcdata());
+  }
+
 }

--- a/src/html/Singleton.php
+++ b/src/html/Singleton.php
@@ -12,8 +12,16 @@
  * Subclasses of :xhp:html-singleton may not contain children. When
  * rendered they will be in singleton (<img />, <br />) form.
  */
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 abstract class :xhp:html-singleton extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children empty;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\empty();
+  }
+
 
   protected function stringify(): string {
     return $this->renderBaseAttrs().'>';

--- a/src/html/tags/a/A.php
+++ b/src/html/tags/a/A.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :a extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string download,
     string href,
@@ -22,5 +25,12 @@ class :a extends :xhp:html-element {
   category %flow, %phrase, %interactive;
   // Should not contain %interactive
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'a';
 }

--- a/src/html/tags/a/Abbr.php
+++ b/src/html/tags/a/Abbr.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :abbr extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'abbr';
 }

--- a/src/html/tags/a/Address.php
+++ b/src/html/tags/a/Address.php
@@ -8,9 +8,19 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :address extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   // May not contain %heading, %sectioning, :header, :footer, or :address
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'address';
 }

--- a/src/html/tags/a/Article.php
+++ b/src/html/tags/a/Article.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :article extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %sectioning;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'article';
 }

--- a/src/html/tags/a/Aside.php
+++ b/src/html/tags/a/Aside.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :aside extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %sectioning;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'aside';
 }

--- a/src/html/tags/a/Audio.php
+++ b/src/html/tags/a/Audio.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :audio extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     bool autoplay,
     bool controls,
@@ -20,5 +23,16 @@ class :audio extends :xhp:html-element {
     string src;
   category %flow, %phrase, %embedded, %interactive;
   children (:source*, :track*, (pcdata | %flow)*);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\anyNumberOf(XHPChild\ofType<:source>()),
+      XHPChild\anyNumberOf(XHPChild\ofType<:track>()),
+      XHPChild\anyNumberOf(
+        XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+      ),
+    );
+  }
+
   protected string $tagName = 'audio';
 }

--- a/src/html/tags/b/B.php
+++ b/src/html/tags/b/B.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :b extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'b';
 }

--- a/src/html/tags/b/Bdi.php
+++ b/src/html/tags/b/Bdi.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :bdi extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'bdi';
 }

--- a/src/html/tags/b/Bdo.php
+++ b/src/html/tags/b/Bdo.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :bdo extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'bdo';
 }

--- a/src/html/tags/b/Blockquote.php
+++ b/src/html/tags/b/Blockquote.php
@@ -8,9 +8,19 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :blockquote extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute string cite;
   category %flow, %sectioning;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'blockquote';
 }

--- a/src/html/tags/b/Body.php
+++ b/src/html/tags/b/Body.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :body extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string onafterprint,
     string onbeforeprint,
@@ -23,5 +26,12 @@ class :body extends :xhp:html-element {
     string onstorage,
     string onunload;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'body';
 }

--- a/src/html/tags/b/Button.php
+++ b/src/html/tags/b/Button.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :button extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     bool autofocus,
     bool disabled,
@@ -25,5 +28,12 @@ class :button extends :xhp:html-element {
   category %flow, %phrase, %interactive;
   // Should not contain interactive
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'button';
 }

--- a/src/html/tags/c/Canvas.php
+++ b/src/html/tags/c/Canvas.php
@@ -8,12 +8,22 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :canvas extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     int height,
     int width;
   category %flow, %phrase, %embedded;
   // Should not contain :table
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'canvas';
 }

--- a/src/html/tags/c/Caption.php
+++ b/src/html/tags/c/Caption.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :caption extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   // Should not contain :table
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'caption';
 }

--- a/src/html/tags/c/Cite.php
+++ b/src/html/tags/c/Cite.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :cite extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'cite';
 }

--- a/src/html/tags/c/Code.php
+++ b/src/html/tags/c/Code.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :code extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'code';
 }

--- a/src/html/tags/c/Colgroup.php
+++ b/src/html/tags/c/Colgroup.php
@@ -8,8 +8,16 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :colgroup extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute int span;
   children (:col)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\ofType<:col>());
+  }
+
   protected string $tagName = 'colgroup';
 }

--- a/src/html/tags/c/ConditionalComment.php
+++ b/src/html/tags/c/ConditionalComment.php
@@ -12,9 +12,19 @@
  * Render an HTML conditional comment. You can choose whatever you like as
  * the conditional statement.
  */
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :x:conditional-comment extends :x:primitive {
+  use XHPChildDeclarationConsistencyValidation;
   attribute string if @required;
   children (pcdata | :xhp)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\ofType<:xhp>()),
+    );
+  }
+
 
   protected function stringify(): string {
     $children = $this->getChildren();

--- a/src/html/tags/d/Data.php
+++ b/src/html/tags/d/Data.php
@@ -8,9 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :data extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute string value @required;
   category %flow, %phrase;
   children (%phrase*);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\category('%phrase'));
+  }
+
   protected string $tagName = 'data';
 }

--- a/src/html/tags/d/Datalist.php
+++ b/src/html/tags/d/Datalist.php
@@ -8,8 +8,19 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :datalist extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (%phrase+ | :option*);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyOf(
+      XHPChild\atLeastOneOf(XHPChild\category('%phrase')),
+      XHPChild\anyNumberOf(XHPChild\ofType<:option>()),
+    );
+  }
+
   protected string $tagName = 'datalist';
 }

--- a/src/html/tags/d/Dd.php
+++ b/src/html/tags/d/Dd.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :dd extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'dd';
 }

--- a/src/html/tags/d/Del.php
+++ b/src/html/tags/d/Del.php
@@ -8,12 +8,22 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :del extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string cite,
     string datetime;
   category %flow, %phrase;
   // transparent
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'del';
 }

--- a/src/html/tags/d/Details.php
+++ b/src/html/tags/d/Details.php
@@ -8,9 +8,20 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :details extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute bool open;
   category %flow, %phrase, %interactive;
   children (:summary, %flow+);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\ofType<:summary>(),
+      XHPChild\atLeastOneOf(XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'details';
 }

--- a/src/html/tags/d/Dfn.php
+++ b/src/html/tags/d/Dfn.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :dfn extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'dfn';
 }

--- a/src/html/tags/d/Dialog.php
+++ b/src/html/tags/d/Dialog.php
@@ -8,9 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :dialog extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute bool open;
   category %flow, %sectioning;
   children (%flow);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\category('%flow');
+  }
+
   protected string $tagName = 'dialog';
 }

--- a/src/html/tags/d/Div.php
+++ b/src/html/tags/d/Div.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :div extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'div';
 }

--- a/src/html/tags/d/Dl.php
+++ b/src/html/tags/d/Dl.php
@@ -8,8 +8,19 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :dl extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (:dt+, :dd+)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\sequence(
+      XHPChild\atLeastOneOf(XHPChild\ofType<:dt>()),
+      XHPChild\atLeastOneOf(XHPChild\ofType<:dd>()),
+    ));
+  }
+
   protected string $tagName = 'dl';
 }

--- a/src/html/tags/d/Doctype.php
+++ b/src/html/tags/d/Doctype.php
@@ -12,8 +12,16 @@
  * Render an <html /> element within a DOCTYPE, XHP has chosen to only support
  * the HTML5 doctype.
  */
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :x:doctype extends :x:primitive {
+  use XHPChildDeclarationConsistencyValidation;
   children (:html);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\ofType<:html>();
+  }
+
 
   protected function stringify(): string {
     $children = $this->getChildren();

--- a/src/html/tags/d/Dt.php
+++ b/src/html/tags/d/Dt.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :dt extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'dt';
 }

--- a/src/html/tags/e/Em.php
+++ b/src/html/tags/e/Em.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :em extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'em';
 }

--- a/src/html/tags/e/Embed.php
+++ b/src/html/tags/e/Embed.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :embed extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     int height,
     string src,
@@ -24,5 +27,12 @@ class :embed extends :xhp:html-element {
 
   category %flow, %phrase, %embedded, %interactive;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'embed';
 }

--- a/src/html/tags/f/Fieldset.php
+++ b/src/html/tags/f/Fieldset.php
@@ -8,12 +8,25 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :fieldset extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     bool disabled,
     string form,
     string name;
   category %flow;
   children (:legend?, (pcdata | %flow)*);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\optional(XHPChild\ofType<:legend>()),
+      XHPChild\anyNumberOf(
+        XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+      ),
+    );
+  }
+
   protected string $tagName = 'fieldset';
 }

--- a/src/html/tags/f/Figcaption.php
+++ b/src/html/tags/f/Figcaption.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :figcaption extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'figcaption';
 }

--- a/src/html/tags/f/Figure.php
+++ b/src/html/tags/f/Figure.php
@@ -8,8 +8,25 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :figure extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %sectioning;
   children ((:figcaption, %flow+) | (%flow+, :figcaption?));
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyOf(
+      XHPChild\sequence(
+        XHPChild\ofType<:figcaption>(),
+        XHPChild\atLeastOneOf(XHPChild\category('%flow')),
+      ),
+      XHPChild\sequence(
+        XHPChild\atLeastOneOf(XHPChild\category('%flow')),
+        XHPChild\optional(XHPChild\ofType<:figcaption>()),
+      ),
+    );
+  }
+
   protected string $tagName = 'figure';
 }

--- a/src/html/tags/f/Footer.php
+++ b/src/html/tags/f/Footer.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :footer extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'footer';
 }

--- a/src/html/tags/f/Form.php
+++ b/src/html/tags/f/Form.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :form extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string action,
     string accept-charset,
@@ -21,5 +24,12 @@ class :form extends :xhp:html-element {
   category %flow;
   // Should not contain :form
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'form';
 }

--- a/src/html/tags/h/H1.php
+++ b/src/html/tags/h/H1.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :h1 extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'h1';
 }

--- a/src/html/tags/h/H2.php
+++ b/src/html/tags/h/H2.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :h2 extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'h2';
 }

--- a/src/html/tags/h/H3.php
+++ b/src/html/tags/h/H3.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :h3 extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'h3';
 }

--- a/src/html/tags/h/H4.php
+++ b/src/html/tags/h/H4.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :h4 extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'h4';
 }

--- a/src/html/tags/h/H5.php
+++ b/src/html/tags/h/H5.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :h5 extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'h5';
 }

--- a/src/html/tags/h/H6.php
+++ b/src/html/tags/h/H6.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :h6 extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'h6';
 }

--- a/src/html/tags/h/Head.php
+++ b/src/html/tags/h/Head.php
@@ -8,7 +8,15 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :head extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (%metadata*);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\category('%metadata'));
+  }
+
   protected string $tagName = 'head';
 }

--- a/src/html/tags/h/Header.php
+++ b/src/html/tags/h/Header.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :header extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %heading;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'header';
 }

--- a/src/html/tags/h/Hgroup.php
+++ b/src/html/tags/h/Hgroup.php
@@ -8,8 +8,23 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :hgroup extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %heading;
   children (:h1 | :h2 | :h3 | :h4 | :h5 | :h6)+;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\atLeastOneOf(XHPChild\anyOf(
+      XHPChild\ofType<:h1>(),
+      XHPChild\ofType<:h2>(),
+      XHPChild\ofType<:h3>(),
+      XHPChild\ofType<:h4>(),
+      XHPChild\ofType<:h5>(),
+      XHPChild\ofType<:h6>(),
+    ));
+  }
+
   protected string $tagName = 'hgroup';
 }

--- a/src/html/tags/h/Html.php
+++ b/src/html/tags/h/Html.php
@@ -8,10 +8,21 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :html extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string manifest,
     string xmlns;
   children (:head, :body);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\ofType<:head>(),
+      XHPChild\ofType<:body>(),
+    );
+  }
+
   protected string $tagName = 'html';
 }

--- a/src/html/tags/i/I.php
+++ b/src/html/tags/i/I.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :i extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'i';
 }

--- a/src/html/tags/i/Ins.php
+++ b/src/html/tags/i/Ins.php
@@ -8,11 +8,21 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :ins extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string cite,
     string datetime;
   category %flow, %phrase;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'ins';
 }

--- a/src/html/tags/k/Kbd.php
+++ b/src/html/tags/k/Kbd.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :kbd extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'kbd';
 }

--- a/src/html/tags/l/Label.php
+++ b/src/html/tags/l/Label.php
@@ -8,12 +8,22 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :label extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string for,
     string form;
   category %flow, %phrase, %interactive;
   // may not contain label
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'label';
 }

--- a/src/html/tags/l/Legend.php
+++ b/src/html/tags/l/Legend.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :legend extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'legend';
 }

--- a/src/html/tags/l/Li.php
+++ b/src/html/tags/l/Li.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :li extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'li';
 }

--- a/src/html/tags/m/Main.php
+++ b/src/html/tags/m/Main.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :main extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'main';
 }

--- a/src/html/tags/m/Map.php
+++ b/src/html/tags/m/Map.php
@@ -8,9 +8,19 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :map extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute string name;
   category %flow, %phrase;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'map';
 }

--- a/src/html/tags/m/Mark.php
+++ b/src/html/tags/m/Mark.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :mark extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'mark';
 }

--- a/src/html/tags/m/Menu.php
+++ b/src/html/tags/m/Menu.php
@@ -8,11 +8,27 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :menu extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string label,
     enum {'popup', 'toolbar'} type;
   category %flow;
   children ((:menuitem | :hr | :menu)* | :li* | %flow*);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyOf(
+      XHPChild\anyNumberOf(XHPChild\anyOf(
+        XHPChild\ofType<:menuitem>(),
+        XHPChild\ofType<:hr>(),
+        XHPChild\ofType<:menu>(),
+      )),
+      XHPChild\anyNumberOf(XHPChild\ofType<:li>()),
+      XHPChild\anyNumberOf(XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'menu';
 }

--- a/src/html/tags/m/Meter.php
+++ b/src/html/tags/m/Meter.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :meter extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     float high,
     float low,
@@ -19,5 +22,12 @@ class :meter extends :xhp:html-element {
   category %flow, %phrase;
   // Should not contain :meter
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'meter';
 }

--- a/src/html/tags/n/Nav.php
+++ b/src/html/tags/n/Nav.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :nav extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'nav';
 }

--- a/src/html/tags/n/Noscript.php
+++ b/src/html/tags/n/Noscript.php
@@ -8,8 +8,20 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :noscript extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %metadata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\anyOf(
+      XHPChild\pcdata(),
+      XHPChild\category('%metadata'),
+      XHPChild\category('%flow'),
+    ));
+  }
+
   category %flow, %phrase, %metadata;
   protected string $tagName = 'noscript';
 }

--- a/src/html/tags/o/Object.php
+++ b/src/html/tags/o/Object.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :object extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string data,
     int height,
@@ -20,5 +23,15 @@ class :object extends :xhp:html-element {
     int width;
   category %flow, %phrase, %embedded, %interactive;
   children (:param*, (pcdata | %flow)*);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\anyNumberOf(XHPChild\ofType<:param>()),
+      XHPChild\anyNumberOf(
+        XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+      ),
+    );
+  }
+
   protected string $tagName = 'object';
 }

--- a/src/html/tags/o/Ol.php
+++ b/src/html/tags/o/Ol.php
@@ -8,12 +8,20 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :ol extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     bool reversed,
     int start,
     enum {'1', 'a', 'A', 'i', 'I'} type;
   category %flow;
   children (:li)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\ofType<:li>());
+  }
+
   protected string $tagName = 'ol';
 }

--- a/src/html/tags/o/Optgroup.php
+++ b/src/html/tags/o/Optgroup.php
@@ -8,10 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :optgroup extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     bool disabled,
     string label;
   children (:option)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\ofType<:option>());
+  }
+
   protected string $tagName = 'optgroup';
 }

--- a/src/html/tags/o/Output.php
+++ b/src/html/tags/o/Output.php
@@ -8,12 +8,22 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :output extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string for,
     string form,
     string name;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'output';
 }

--- a/src/html/tags/p/P.php
+++ b/src/html/tags/p/P.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :p extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'p';
 }

--- a/src/html/tags/p/Picture.php
+++ b/src/html/tags/p/Picture.php
@@ -8,8 +8,19 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :picture extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (:source*, :img);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\anyNumberOf(XHPChild\ofType<:source>()),
+      XHPChild\ofType<:img>(),
+    );
+  }
+
   protected string $tagName = 'picture';
 }

--- a/src/html/tags/p/Pre.php
+++ b/src/html/tags/p/Pre.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :pre extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'pre';
 }

--- a/src/html/tags/p/Progress.php
+++ b/src/html/tags/p/Progress.php
@@ -8,12 +8,22 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :progress extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     float max,
     float value;
   category %flow, %phrase;
   // Should not contain :progress
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'progress';
 }

--- a/src/html/tags/q/Q.php
+++ b/src/html/tags/q/Q.php
@@ -8,9 +8,19 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :q extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute string cite;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'q';
 }

--- a/src/html/tags/r/Rb.php
+++ b/src/html/tags/r/Rb.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :rb extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %phrase)+;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\atLeastOneOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'rb';
 }

--- a/src/html/tags/r/Rp.php
+++ b/src/html/tags/r/Rp.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :rp extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %phrase)+;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\atLeastOneOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'rp';
 }

--- a/src/html/tags/r/Rt.php
+++ b/src/html/tags/r/Rt.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :rt extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %phrase)+;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\atLeastOneOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'rt';
 }

--- a/src/html/tags/r/Rtc.php
+++ b/src/html/tags/r/Rtc.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :rtc extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %phrase)+;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\atLeastOneOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'rtc';
 }

--- a/src/html/tags/r/Ruby.php
+++ b/src/html/tags/r/Ruby.php
@@ -8,10 +8,28 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :ruby extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (
     (pcdata | :rb)+ | ((:rp, :rt) | (:rp, :rtc) | (:rt, :rp) | (:rtc, :rp))+
   );
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyOf(
+      XHPChild\atLeastOneOf(
+        XHPChild\anyOf(XHPChild\pcdata(), XHPChild\ofType<:rb>()),
+      ),
+      XHPChild\atLeastOneOf(XHPChild\anyOf(
+        XHPChild\sequence(XHPChild\ofType<:rp>(), XHPChild\ofType<:rt>()),
+        XHPChild\sequence(XHPChild\ofType<:rp>(), XHPChild\ofType<:rtc>()),
+        XHPChild\sequence(XHPChild\ofType<:rt>(), XHPChild\ofType<:rp>()),
+        XHPChild\sequence(XHPChild\ofType<:rtc>(), XHPChild\ofType<:rp>()),
+      )),
+    );
+  }
+
   protected string $tagName = 'ruby';
 }

--- a/src/html/tags/s/S.php
+++ b/src/html/tags/s/S.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :s extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 's';
 }

--- a/src/html/tags/s/Samp.php
+++ b/src/html/tags/s/Samp.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :samp extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'samp';
 }

--- a/src/html/tags/s/Section.php
+++ b/src/html/tags/s/Section.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :section extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %sectioning;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'section';
 }

--- a/src/html/tags/s/Select.php
+++ b/src/html/tags/s/Select.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :select extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     bool autofocus,
     bool disabled,
@@ -19,5 +22,12 @@ class :select extends :xhp:html-element {
     int size;
   category %flow, %phrase, %interactive;
   children (:option | :optgroup)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\ofType<:option>(), XHPChild\ofType<:optgroup>()),
+    );
+  }
+
   protected string $tagName = 'select';
 }

--- a/src/html/tags/s/Small.php
+++ b/src/html/tags/s/Small.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :small extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'small';
 }

--- a/src/html/tags/s/Span.php
+++ b/src/html/tags/s/Span.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :span extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'span';
 }

--- a/src/html/tags/s/Strong.php
+++ b/src/html/tags/s/Strong.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :strong extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'strong';
 }

--- a/src/html/tags/s/Sub.php
+++ b/src/html/tags/s/Sub.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :sub extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'sub';
 }

--- a/src/html/tags/s/Summary.php
+++ b/src/html/tags/s/Summary.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :summary extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'summary';
 }

--- a/src/html/tags/s/Sup.php
+++ b/src/html/tags/s/Sup.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :sup extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'sup';
 }

--- a/src/html/tags/t/Table.php
+++ b/src/html/tags/t/Table.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :table extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     int border,
     bool sortable;
@@ -19,5 +22,30 @@ class :table extends :xhp:html-element {
     :thead?,
     ((:tfoot, (:tbody+ | :tr*)) | ((:tbody+ | :tr*), :tfoot?))
   );
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\optional(XHPChild\ofType<:caption>()),
+      XHPChild\anyNumberOf(XHPChild\ofType<:colgroup>()),
+      XHPChild\optional(XHPChild\ofType<:thead>()),
+      XHPChild\anyOf(
+        XHPChild\sequence(
+          XHPChild\ofType<:tfoot>(),
+          XHPChild\anyOf(
+            XHPChild\atLeastOneOf(XHPChild\ofType<:tbody>()),
+            XHPChild\anyNumberOf(XHPChild\ofType<:tr>()),
+          ),
+        ),
+        XHPChild\sequence(
+          XHPChild\anyOf(
+            XHPChild\atLeastOneOf(XHPChild\ofType<:tbody>()),
+            XHPChild\anyNumberOf(XHPChild\ofType<:tr>()),
+          ),
+          XHPChild\optional(XHPChild\ofType<:tfoot>()),
+        ),
+      ),
+    );
+  }
+
   protected string $tagName = 'table';
 }

--- a/src/html/tags/t/Tbody.php
+++ b/src/html/tags/t/Tbody.php
@@ -8,7 +8,15 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :tbody extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (:tr)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\ofType<:tr>());
+  }
+
   protected string $tagName = 'tbody';
 }

--- a/src/html/tags/t/Td.php
+++ b/src/html/tags/t/Td.php
@@ -8,11 +8,21 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :td extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     int colspan,
     string headers,
     int rowspan;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'td';
 }

--- a/src/html/tags/t/Tfoot.php
+++ b/src/html/tags/t/Tfoot.php
@@ -8,7 +8,15 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :tfoot extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (:tr)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\ofType<:tr>());
+  }
+
   protected string $tagName = 'tfoot';
 }

--- a/src/html/tags/t/Th.php
+++ b/src/html/tags/t/Th.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :th extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     string abbr,
     int colspan,
@@ -17,5 +20,12 @@ class :th extends :xhp:html-element {
     enum {'col', 'colgroup', 'row', 'rowgroup'} scope,
     string sorted;
   children (pcdata | %flow)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+    );
+  }
+
   protected string $tagName = 'th';
 }

--- a/src/html/tags/t/Thead.php
+++ b/src/html/tags/t/Thead.php
@@ -8,7 +8,15 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :thead extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (:tr)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\ofType<:tr>());
+  }
+
   protected string $tagName = 'thead';
 }

--- a/src/html/tags/t/Time.php
+++ b/src/html/tags/t/Time.php
@@ -8,9 +8,19 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :time extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute string datetime;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'time';
 }

--- a/src/html/tags/t/Tr.php
+++ b/src/html/tags/t/Tr.php
@@ -8,7 +8,17 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :tr extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   children (:th | :td)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\ofType<:th>(), XHPChild\ofType<:td>()),
+    );
+  }
+
   protected string $tagName = 'tr';
 }

--- a/src/html/tags/t/Tt.php
+++ b/src/html/tags/t/Tt.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :tt extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'tt';
 }

--- a/src/html/tags/u/U.php
+++ b/src/html/tags/u/U.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :u extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'u';
 }

--- a/src/html/tags/u/Ul.php
+++ b/src/html/tags/u/Ul.php
@@ -8,8 +8,16 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :ul extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow;
   children (:li)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(XHPChild\ofType<:li>());
+  }
+
   protected string $tagName = 'ul';
 }

--- a/src/html/tags/v/Var.php
+++ b/src/html/tags/v/Var.php
@@ -8,8 +8,18 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :var extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   category %flow, %phrase;
   children (pcdata | %phrase)*;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
   protected string $tagName = 'var';
 }

--- a/src/html/tags/v/Video.php
+++ b/src/html/tags/v/Video.php
@@ -8,7 +8,10 @@
  *
  */
 
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
 class :video extends :xhp:html-element {
+  use XHPChildDeclarationConsistencyValidation;
   attribute
     bool autoplay,
     bool controls,
@@ -23,5 +26,16 @@ class :video extends :xhp:html-element {
     int width;
   category %flow, %phrase, %embedded, %interactive;
   children (:source*, :track*, (pcdata | %flow)*);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      XHPChild\anyNumberOf(XHPChild\ofType<:source>()),
+      XHPChild\anyNumberOf(XHPChild\ofType<:track>()),
+      XHPChild\anyNumberOf(
+        XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%flow')),
+      ),
+    );
+  }
+
   protected string $tagName = 'video';
 }


### PR DESCRIPTION
This is PR 1 of 2: add traits, and enforce consistency.

PR 2 of 2 will be later, and will:
- remove the old declaration
- change the trait to use new enforcement instead of consistency
  checking

refs #212

```
fredemmott@fredemmott-mm1 xhp-lib % ~/code/hhast/bin/hhast-migrate --add-xhp-children-declaration-method src/
fredemmott@fredemmott-mm1 xhp-lib % git diff | hackfmt --diff
```