### PR TITLE
Migrate to hack arrays internally

### DIFF
--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -272,6 +272,9 @@ abstract class :x:composable-element extends :xhp {
     return null;
   }
 
+  // @reviewer, the memoize would make it so that changes made
+  // to this map are observable to the next caller.
+  // This would be a mild bc break, but one to note non the less.
   <<__MemoizeLSB>>
   final public static function __xhpReflectionAttributes(
   ): Map<string, ReflectionXHPAttribute> {
@@ -471,8 +474,8 @@ abstract class :x:composable-element extends :xhp {
    * that are rendered as children of that root element will receive this
    * context WHEN RENDERED. The context will not be available before render.
    *
-   * @param Map $context  A map of key/value pairs
-   * @return :xhp         $this
+   * @param KeyedContainer $context  A map of key/value pairs
+   * @return :xhp                    $this
    */
   final public function addContextMap(
     KeyedContainer<string, mixed> $context,

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -10,7 +10,7 @@
 
 use type Facebook\TypeAssert\IncorrectTypeException;
 use namespace Facebook\TypeAssert;
-use namespace HH\Lib\{C, Dict, Str};
+use namespace HH\Lib\{C, Dict, Keyset, Str};
 
 abstract class :x:composable-element extends :xhp {
   private dict<string, mixed> $attributes = dict[];
@@ -306,7 +306,7 @@ abstract class :x:composable-element extends :xhp {
   final public static function __xhpReflectionCategoryDeclaration(
   ): Set<string> {
     return new Set(
-      \array_keys(self::emptyInstance()->__xhpCategoryDeclaration()),
+      Keyset\keys(self::emptyInstance()->__xhpCategoryDeclaration()),
     );
   }
 

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -14,9 +14,7 @@ use namespace HH\Lib\{C, Dict, Keyset, Str};
 
 abstract class :x:composable-element extends :xhp {
   private dict<string, mixed> $attributes = dict[];
-  // Cannot be changed just yet because:
-  // - getChildren exposes a mutable Vector when call with an empty selector
-  // - prependChild would become a lot slower
+  // Cannot be changed just yet because prependChild would become a lot slower
   private Vector<XHPChild> $children = Vector {};
   private dict<string, mixed> $context = dict[];
 
@@ -173,15 +171,12 @@ abstract class :x:composable-element extends :xhp {
         }
       }
     } else {
-      $children = $this->children;
+      // Clone the private Vector
+      return new Vector($this->children);
     }
 
-    // Why this complex check to prevent calling new Vector(...) on $children?
-    // The return of this function is mutable and it directly exposes
-    // the $this->children on empty selectors.
-    // We'd need to make sure that no calling code is modifying the private Vector
-    // by calling this function with an empty selector.
-    return $children is Vector<_> ? $children : new Vector($children);
+    // Transform the vec into a Vector
+    return new Vector($children);
   }
 
 

--- a/src/core/Primitive.php
+++ b/src/core/Primitive.php
@@ -8,6 +8,8 @@
  *
  */
 
+use namespace HH\Lib\Dict;
+
 /**
  * :x:primitive lays down the foundation for very low-level elements. You
  * should directly :x:primitive only if you are creating a core element that
@@ -28,7 +30,7 @@ abstract class :x:primitive extends :x:composable-element implements XHPRoot {
 
   final private async function __flushElementChildren(): Awaitable<void> {
     $children = $this->getChildren();
-    $awaitables = Map {};
+    $awaitables = dict[];
     foreach ($children as $idx => $child) {
       if ($child is :x:composable-element) {
         $child->__transferContext($this->getAllContexts());
@@ -36,7 +38,7 @@ abstract class :x:primitive extends :x:composable-element implements XHPRoot {
       }
     }
     if ($awaitables) {
-      $awaited = await HH\Asio\m($awaitables);
+      $awaited = await Dict\from_async($awaitables);
       foreach ($awaited as $idx => $child) {
         $children[$idx] = $child;
       }

--- a/src/core/ReflectionXHPAttribute.php
+++ b/src/core/ReflectionXHPAttribute.php
@@ -8,6 +8,8 @@
  *
  */
 
+use namespace HH\Lib\C;
+
 enum XHPAttributeType: int {
   TYPE_STRING = 1;
   TYPE_BOOL = 2;
@@ -30,7 +32,7 @@ class ReflectionXHPAttribute {
   private mixed $defaultValue;
   private bool $required;
 
-  private static ImmSet<string> $specialAttributes = ImmSet {'data', 'aria'};
+  private static keyset<string> $specialAttributes = keyset['data', 'aria'];
 
   public function __construct(private string $name, array<int, mixed> $decl) {
     $this->type = XHPAttributeType::assert($decl[0]);
@@ -77,6 +79,7 @@ class ReflectionXHPAttribute {
     return $v;
   }
 
+  // @reviewer modified sets may be observed by the next caller
   <<__Memoize>>
   public function getEnumValues(): Set<string> {
     $t = $this->getValueType();
@@ -102,7 +105,7 @@ class ReflectionXHPAttribute {
   public static function IsSpecial(string $attr): bool {
     return strlen($attr) >= 6 &&
       $attr[4] === '-' &&
-      self::$specialAttributes->contains(substr($attr, 0, 4));
+      C\contains_key(self::$specialAttributes, substr($attr, 0, 4));
   }
 
   public function __toString(): string {

--- a/src/core/XHP.php
+++ b/src/core/XHP.php
@@ -22,6 +22,10 @@ abstract class :xhp implements XHPChild, JsonSerializable {
   abstract public function appendChild(mixed $child): this;
   abstract public function prependChild(mixed $child): this;
   abstract public function replaceChildren(...): this;
+  // This type signature is problematic.
+  // ComposableElement returns its private mutable instance on an empty selector.
+  // We might need to take a conservative step here via ImmVector,
+  // before going to vec to prevent very subtle breaks.
   abstract public function getChildren(
     ?string $selector = null,
   ): Vector<XHPChild>;

--- a/src/core/XHP.php
+++ b/src/core/XHP.php
@@ -22,10 +22,6 @@ abstract class :xhp implements XHPChild, JsonSerializable {
   abstract public function appendChild(mixed $child): this;
   abstract public function prependChild(mixed $child): this;
   abstract public function replaceChildren(...): this;
-  // This type signature is problematic.
-  // ComposableElement returns its private mutable instance on an empty selector.
-  // We might need to take a conservative step here via ImmVector,
-  // before going to vec to prevent very subtle breaks.
   abstract public function getChildren(
     ?string $selector = null,
   ): Vector<XHPChild>;

--- a/src/html/XHPHelpers.php
+++ b/src/html/XHPHelpers.php
@@ -8,6 +8,7 @@
  *
  */
 
+use namespace Facebook\XHP\_Private;
 use namespace HH\Lib\C;
 
 interface HasXHPHelpers
@@ -31,7 +32,7 @@ trait XHPHelpers implements HasXHPHelpers {
    * $target.
    */
   final public function copyAllAttributes(:x:composable-element $target): void {
-    $this->transferAttributesImpl($target, Set {});
+    $this->transferAttributesImpl($target, ImmSet {});
   }
 
   /*
@@ -50,7 +51,7 @@ trait XHPHelpers implements HasXHPHelpers {
    */
   final public function copyAttributesExcept(
     :x:composable-element $target,
-    Set<string> $ignore,
+    _Private\SetLike<string> $ignore,
   ): void {
     $this->transferAttributesImpl($target, $ignore);
   }
@@ -62,7 +63,7 @@ trait XHPHelpers implements HasXHPHelpers {
   final public function transferAllAttributes(
     :x:composable-element $target,
   ): void {
-    $this->transferAttributesImpl($target, Set {}, true);
+    $this->transferAttributesImpl($target, ImmSet {}, true);
   }
 
   /*
@@ -82,7 +83,7 @@ trait XHPHelpers implements HasXHPHelpers {
    */
   final public function transferAttributesExcept(
     :x:composable-element $target,
-    Set<string> $ignore,
+    _Private\SetLike<string> $ignore,
   ): void {
     $this->transferAttributesImpl($target, $ignore, true);
   }
@@ -93,13 +94,13 @@ trait XHPHelpers implements HasXHPHelpers {
    */
   final private function transferAttributesImpl(
     :x:composable-element $target,
-    ?Set<string> $ignore = null,
+    ?_Private\SetLike<string> $ignore = null,
     bool $remove = false,
   ): void {
     if ($ignore === null) {
       $ignore = :xhp:html-element::__xhpAttributeDeclaration();
     } else {
-      $ignore = array_fill_keys($ignore->toArray(), true);
+      $ignore = array_fill_keys(keyset($ignore), true);
     }
 
     $compatible = $target::__xhpAttributeDeclaration();

--- a/src/html/XHPHelpers.php
+++ b/src/html/XHPHelpers.php
@@ -8,6 +8,8 @@
  *
  */
 
+use namespace HH\Lib\C;
+
 interface HasXHPHelpers
   extends HasXHPBaseHTMLHelpers, XHPHasTransferAttributes {
 }
@@ -100,11 +102,11 @@ trait XHPHelpers implements HasXHPHelpers {
       $ignore = array_fill_keys($ignore->toArray(), true);
     }
 
-    $compatible = new Map($target::__xhpAttributeDeclaration());
+    $compatible = $target::__xhpAttributeDeclaration();
     $transferAttributes = array_diff_key($this->getAttributes(), $ignore);
     foreach ($transferAttributes as $attribute => $value) {
       if (
-        $compatible->containsKey($attribute) ||
+        C\contains_key($compatible, $attribute) ||
         ReflectionXHPAttribute::IsSpecial($attribute)
       ) {
         try {
@@ -139,7 +141,7 @@ trait XHPHelpers implements HasXHPHelpers {
 
   protected function getAttributeNamesThatAppendValuesOnTransfer(
   ): ImmSet<string> {
-    return ImmSet { 'class' };
+    return ImmSet {'class'};
   }
 
   final public function transferAttributesToRenderedRoot(

--- a/src/private/types.php
+++ b/src/private/types.php
@@ -1,0 +1,18 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\_Private;
+
+/**
+ * This typehint can be flipped to keyset<T> with no internal breakages.
+ * There is no (keyset<T>|ConstSet<T>) type to use.
+ * Making this switch must be a BC break.
+ */
+type SetLike<T as arraykey> = \ConstSet<T>;

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -8,6 +8,7 @@
  *
  */
 
+use namespace HH\Lib\Math;
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 
@@ -112,17 +113,19 @@ class AsyncTest extends Facebook\HackTest\HackTest {
     );
 
     $log = :async:par-test::$log;
-    $by_node = Map {'a' => Map {}, 'b' => Map {}, 'c' => Map {}};
+    $by_node = dict['a' => dict[], 'b' => dict[], 'c' => dict[]];
 
     foreach ($log as $idx => $data) {
       list($label, $action) = $data;
       $by_node[$label][$action] = $idx;
     }
 
-    $max_start = max($by_node->map($x ==> $x['start']));
-    $min_mid = min($by_node->map($x ==> $x['mid']));
-    $max_mid = max($by_node->map($x ==> $x['mid']));
-    $min_finish = min($by_node->map($x ==> $x['finish']));
+    // Math\max_byx() addition to the HSL?
+    $max_start = Math\max_by($by_node, $x ==> $x['start']) as nonnull['start'];
+    $min_mid = Math\min_by($by_node, $x ==> $x['mid']) as nonnull['mid'];
+    $max_mid = Math\max_by($by_node, $x ==> $x['mid']) as nonnull['mid'];
+    // hackfmt-ignore
+    $min_finish = Math\max_by($by_node, $x ==> $x['finish']) as nonnull['finish'];
 
     expect($min_mid)->toBeGreaterThan(
       $max_start,

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -55,11 +55,11 @@ class ReflectionTest extends Facebook\HackTest\HackTest {
     expect($attrs)->toNotBeEmpty();
     expect($attrs?->map($attr ==> /* HH_FIXME[4281] */(string)$attr))
       ->toHaveSameContentAs(
-        Map {
+        dict[
           'mystring' => 'string mystring @required',
           'myenum' => "enum {'herp', 'derp'} myenum",
           'mystringwithdefault' => "string mystringwithdefault = 'mydefault'",
-        },
+        ],
       );
   }
 


### PR DESCRIPTION
This only touches the implementation details.
The public and protected API (and private in traits) remains backwards compatible.
Mostly done to make the migration process easier later.
