### PR TITLE
Rename :x:composable_element to :x:node

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -83,4 +83,4 @@ array(
 )
 ```
 
-These constants are currently declared in `:x:composable_element`.
+These constants are currently declared in `:x:node`.

--- a/src/children/XHPChildDeclarationConsistencyValidation.hack
+++ b/src/children/XHPChildDeclarationConsistencyValidation.hack
@@ -11,7 +11,7 @@ use namespace \Facebook\XHP\ChildValidation as XHPChild;
 
 /** Verify that a new child declaration matches the legacy codegen. */
 trait XHPChildDeclarationConsistencyValidation {
-  require extends :x:composable_element;
+  require extends :x:node;
 
   abstract protected static function getChildrenDeclaration(
   ): XHPChild\Constraint;

--- a/src/children/XHPChildValidation.hack
+++ b/src/children/XHPChildValidation.hack
@@ -11,7 +11,7 @@ use namespace \Facebook\XHP\ChildValidation as XHPChild;
 
 /** Verify that a new child declaration matches the legacy codegen. */
 trait XHPChildValidation {
-  require extends :x:composable_element;
+  require extends :x:node;
 
   abstract protected static function getChildrenDeclaration(
   ): XHPChild\Constraint;

--- a/src/core/Element.hack
+++ b/src/core/Element.hack
@@ -14,7 +14,7 @@
  * This is important because most elements should not be dealing with strings
  * of markup.
  */
-abstract xhp class x:element extends :x:composable_element implements XHPRoot {
+abstract xhp class x:element extends :x:node implements XHPRoot {
   abstract protected function renderAsync(): Awaitable<XHPRoot>;
 
   final public async function toStringAsync(): Awaitable<string> {

--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -11,7 +11,7 @@ use type Facebook\TypeAssert\IncorrectTypeException;
 use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Dict, Keyset, Str, Vec};
 
-abstract xhp class x:composable_element extends :xhp {
+abstract xhp class x:node extends :xhp {
   protected bool $__isRendered = false;
   private dict<string, mixed> $attributes = dict[];
   private vec<XHPChild> $children = vec[];
@@ -21,7 +21,7 @@ abstract xhp class x:composable_element extends :xhp {
   }
 
   /**
-   * A new :x:composable_element is instantiated for every literal tag
+   * A new :x:node is instantiated for every literal tag
    * expression in the script.
    *
    * The following code:
@@ -47,7 +47,7 @@ abstract xhp class x:composable_element extends :xhp {
     foreach ($attributes as $key => $value) {
       if (self::isSpreadKey($key)) {
         invariant(
-          $value is :x:composable_element,
+          $value is :x:node,
           "Only XHP can be used with an attribute spread operator",
         );
         $this->spreadElementImpl($value);
@@ -299,7 +299,7 @@ abstract xhp class x:composable_element extends :xhp {
    * Defaults from $xhp are copied as well, if they are present.
    */
   protected final function spreadElementImpl(
-    :x:composable_element $element,
+    :x:node $element,
   ): void {
     $attrs = $element::__xhpReflectionAttributes()
       |> Dict\filter($$, $attr ==> $attr->hasDefaultValue())

--- a/src/core/Primitive.hack
+++ b/src/core/Primitive.hack
@@ -16,7 +16,7 @@ use namespace HH\Lib\Dict;
  * from :x:element.
  */
 abstract xhp class x:primitive
-  extends :x:composable_element
+  extends :x:node
   implements XHPRoot {
   abstract protected function stringifyAsync(): Awaitable<string>;
 
@@ -29,7 +29,7 @@ abstract xhp class x:primitive
     $children = $this->getChildren();
     $awaitables = dict[];
     foreach ($children as $idx => $child) {
-      if ($child is :x:composable_element) {
+      if ($child is :x:node) {
         $child->__transferContext($this->getAllContexts());
         $awaitables[$idx] = $child->__flushSubtree();
       }

--- a/src/core/XHPRoot.hack
+++ b/src/core/XHPRoot.hack
@@ -8,5 +8,5 @@
  */
 
 interface XHPRoot extends XHPChild {
-  require extends :x:composable_element;
+  require extends :x:node;
 }

--- a/src/exceptions/InvalidChildrenException.hack
+++ b/src/exceptions/InvalidChildrenException.hack
@@ -8,7 +8,7 @@
  */
 
 class XHPInvalidChildrenException extends XHPException {
-  public function __construct(:x:composable_element $that, int $index) {
+  public function __construct(:x:node $that, int $index) {
     parent::__construct(
       'Element `'.
       XHPException::getElementName($that).

--- a/src/html/HasXHPHTMLHelpers.hack
+++ b/src/html/HasXHPHTMLHelpers.hack
@@ -8,7 +8,7 @@
  */
 
 interface HasXHPHTMLHelpers {
-  require extends :x:composable_element;
+  require extends :x:node;
 
   public function addClass(string $class): this;
   public function conditionClass(bool $cond, string $class): this;

--- a/src/html/XHPAttributeClobbering_DEPRECATED.hack
+++ b/src/html/XHPAttributeClobbering_DEPRECATED.hack
@@ -12,7 +12,7 @@ use namespace HH\Lib\{C, Dict};
 
 interface HasXHPAttributeClobbering_DEPRECATED extends HasXHPHTMLHelpers {
   public function transferAttributesToRenderedRoot(
-    :x:composable_element $root,
+    :x:node $root,
   ): void;
 }
 
@@ -24,7 +24,7 @@ interface HasXHPAttributeClobbering_DEPRECATED extends HasXHPHTMLHelpers {
  */
 trait XHPAttributeClobbering_DEPRECATED
   implements HasXHPAttributeClobbering_DEPRECATED {
-  require extends :x:composable_element;
+  require extends :x:node;
 
   use XHPHTMLHelpers;
 
@@ -32,7 +32,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * Copies all attributes that are set on $this and valid on $target to
    * $target.
    */
-  final public function copyAllAttributes(:x:composable_element $target): void {
+  final public function copyAllAttributes(:x:node $target): void {
     $this->transferAttributesImpl($target, keyset[]);
   }
 
@@ -41,7 +41,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * $target to $target.
    */
   final public function copyCustomAttributes(
-    :x:composable_element $target,
+    :x:node $target,
   ): void {
     $this->transferAttributesImpl($target);
   }
@@ -51,7 +51,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * valid on $target to $target.
    */
   final public function copyAttributesExcept(
-    :x:composable_element $target,
+    :x:node $target,
     keyset<string> $ignore,
   ): void {
     $this->transferAttributesImpl($target, $ignore);
@@ -62,7 +62,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * $target.
    */
   final public function transferAllAttributes(
-    :x:composable_element $target,
+    :x:node $target,
   ): void {
     $this->transferAttributesImpl($target, keyset[]);
   }
@@ -72,7 +72,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * $target to $target.
    */
   final public function transferCustomAttributes(
-    :x:composable_element $target,
+    :x:node $target,
   ): void {
     $this->transferAttributesImpl($target, null);
   }
@@ -83,7 +83,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * $this.
    */
   final public function transferAttributesExcept(
-    :x:composable_element $target,
+    :x:node $target,
     keyset<string> $ignore,
   ): void {
     $this->transferAttributesImpl($target, $ignore);
@@ -94,7 +94,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * directly. Instead, use one of the transfer/copy flavors above.
    */
   final private function transferAttributesImpl(
-    :x:composable_element $target,
+    :x:node $target,
     ?keyset<string> $ignore = null,
     bool $remove = false,
   ): void {
@@ -121,7 +121,7 @@ trait XHPAttributeClobbering_DEPRECATED
   }
 
   final public function transferAttributesToRenderedRoot(
-    :x:composable_element $root,
+    :x:node $root,
   ): void {
     $attributes = $this->getAttributes();
 

--- a/src/html/XHPHTMLHelpers.hack
+++ b/src/html/XHPHTMLHelpers.hack
@@ -9,7 +9,7 @@
 
 
 trait XHPHTMLHelpers implements HasXHPHTMLHelpers {
-  require extends :x:composable_element;
+  require extends :x:node;
 
   /*
    * Appends a string to the "class" attribute (space separated).

--- a/src/reflection/ReflectionXHPClass.hack
+++ b/src/reflection/ReflectionXHPClass.hack
@@ -11,7 +11,7 @@ use namespace HH\Lib\C;
 
 class ReflectionXHPClass {
   public function __construct(
-    private classname<:x:composable_element> $className,
+    private classname<:x:node> $className,
   ) {
     invariant(
       class_exists($this->className),
@@ -24,7 +24,7 @@ class ReflectionXHPClass {
     return new ReflectionClass($this->getClassName());
   }
 
-  public function getClassName(): classname<:x:composable_element> {
+  public function getClassName(): classname<:x:node> {
     return $this->className;
   }
 

--- a/tests/ChildRuleTest.hack
+++ b/tests/ChildRuleTest.hack
@@ -264,7 +264,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
 
   <<DataProvider('toStringProvider')>>
   public function testToString(
-    :x:composable_element $elem,
+    :x:node $elem,
     string $expected,
   ): void {
     expect($elem->__getChildrenDeclaration())->toEqual($expected);


### PR DESCRIPTION
- more DOM-like
- underscores are nasty
- I find the naming confusing: I expected `:x:composable_element` to be
  a subtype of `:x:element`, not a supertype.

refs #220