### PR TITLE
Move core nodes and exceptions to namespaces

### DIFF
--- a/src/children/XHPChildDeclarationConsistencyValidation.hack
+++ b/src/children/XHPChildDeclarationConsistencyValidation.hack
@@ -7,11 +7,12 @@
  *
  */
 
-use namespace \Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Elements\Core as x;
 
 /** Verify that a new child declaration matches the legacy codegen. */
 trait XHPChildDeclarationConsistencyValidation {
-  require extends :x:node;
+  require extends x\node;
 
   abstract protected static function getChildrenDeclaration(
   ): XHPChild\Constraint;

--- a/src/children/XHPChildValidation.hack
+++ b/src/children/XHPChildValidation.hack
@@ -7,11 +7,12 @@
  *
  */
 
-use namespace \Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Elements\Core as x;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 /** Verify that a new child declaration matches the legacy codegen. */
 trait XHPChildValidation {
-  require extends :x:node;
+  require extends x\node;
 
   abstract protected static function getChildrenDeclaration(
   ): XHPChild\Constraint;
@@ -25,7 +26,7 @@ trait XHPChildValidation {
   final public function validateChildren(): void {
     invariant(
       $this->__xhpChildrenDeclaration() ===
-        :x:element::__NO_LEGACY_CHILDREN_DECLARATION,
+        x\element::__NO_LEGACY_CHILDREN_DECLARATION,
       "The XHPChildValidation trait can not be used with a 'children' ".
       "declaration; override 'getChildrenDeclaration()'' instead",
     );

--- a/src/core/AlwaysValidChild.hack
+++ b/src/core/AlwaysValidChild.hack
@@ -7,14 +7,15 @@
  *
  */
 
+namespace Facebook\XHP;
+
 /**
- * INCREDIBLY DANGEROUS: Marks an object as being able to provide an HTML
- * string.
+ * INCREDIBLY DANGEROUS: Marks an object as a valid child of *any* element,
+ * ignoring any child rules.
  *
  * This is useful when migrating to XHP as it allows you to embed non-XHP
- * content, usually in combination with XHPAlwaysValidChild; see MIGRATING.md
+ * content, usually in combination with XHPUnsafeRenderable; see MIGRATING.md
  * for more information.
  */
-interface XHPUnsafeRenderable extends XHPChild {
-  public function toHTMLStringAsync(): Awaitable<string>;
+interface AlwaysValidChild {
 }

--- a/src/core/Element.hack
+++ b/src/core/Element.hack
@@ -7,15 +7,17 @@
  *
  */
 
+namespace Facebook\XHP\Elements\Core;
+
 /**
- * :x:element defines an interface that all user-land elements should subclass
- * from. The main difference between :x:element and :x:primitive is that
- * subclasses of :x:element should implement `render()` instead of `stringify`.
+ * element defines an interface that all user-land elements should subclass
+ * from. The main difference between element and primitive is that
+ * subclasses of element should implement `render()` instead of `stringify`.
  * This is important because most elements should not be dealing with strings
  * of markup.
  */
-abstract xhp class x:element extends :x:node implements XHPRoot {
-  abstract protected function renderAsync(): Awaitable<XHPRoot>;
+abstract xhp class element extends node implements \XHPRoot {
+  abstract protected function renderAsync(): Awaitable<\XHPRoot>;
 
   final public async function toStringAsync(): Awaitable<string> {
     $that = await $this->__flushRenderedRootElement();
@@ -23,22 +25,22 @@ abstract xhp class x:element extends :x:node implements XHPRoot {
     return $ret;
   }
 
-  final protected async function __flushSubtree(): Awaitable<:x:primitive> {
+  final protected async function __flushSubtree(): Awaitable<primitive> {
     $that = await $this->__flushRenderedRootElement();
     return await $that->__flushSubtree();
   }
 
-  protected async function __renderAndProcess(): Awaitable<XHPRoot> {
+  protected async function __renderAndProcess(): Awaitable<\XHPRoot> {
     invariant(!$this->__isRendered, "Attempted to render XHP element twice");
     $this->__isRendered = true;
-    if (:xhp::isChildValidationEnabled()) {
+    if (xhp::isChildValidationEnabled()) {
       $this->validateChildren();
     }
 
     $composed = await $this->renderAsync();
 
     $composed->__transferContext($this->getAllContexts());
-    if ($this is HasXHPAttributeClobbering_DEPRECATED) {
+    if ($this is \HasXHPAttributeClobbering_DEPRECATED) {
       $this->transferAttributesToRenderedRoot($composed);
     }
 
@@ -46,18 +48,18 @@ abstract xhp class x:element extends :x:node implements XHPRoot {
   }
 
   final protected async function __flushRenderedRootElement(
-  ): Awaitable<:x:primitive> {
+  ): Awaitable<primitive> {
     $that = $this;
-    // Flush root elements returned from render() to an :x:primitive
-    while ($that is :x:element) {
+    // Flush root elements returned from render() to an primitive
+    while ($that is element) {
       $that = await $that->__renderAndProcess();
     }
 
-    if ($that is :x:primitive) {
+    if ($that is primitive) {
       return $that;
     }
 
-    // render() must always (eventually) return :x:primitive
-    throw new XHPCoreRenderException($this, $that);
+    // render() must always (eventually) return primitive
+    throw new \Facebook\XHP\CoreRenderException($this, $that);
   }
 }

--- a/src/core/Frag.hack
+++ b/src/core/Frag.hack
@@ -7,6 +7,8 @@
  *
  */
 
+namespace Facebook\XHP\Elements\Core;
+
 use namespace HH\Lib\{Str, Vec};
 
 /**
@@ -15,11 +17,11 @@ use namespace HH\Lib\{Str, Vec};
  * element the <x:frag /> will disappear and each child will be sequentially
  * appended to the element.
  */
-xhp class x:frag extends :x:primitive {
+xhp class frag extends primitive {
   protected async function stringifyAsync(): Awaitable<string> {
     return await Vec\map_async(
       $this->getChildren(),
-      async $child ==> await :xhp::renderChildAsync($child),
+      async $child ==> await xhp::renderChildAsync($child),
     )
       |> Str\join($$, '');
   }

--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -7,14 +7,16 @@
  *
  */
 
+namespace Facebook\XHP\Elements\Core;
+
 use type Facebook\TypeAssert\IncorrectTypeException;
 use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Dict, Keyset, Str, Vec};
 
-abstract xhp class x:node extends :xhp {
+abstract xhp class node extends namespace\xhp {
   protected bool $__isRendered = false;
   private dict<string, mixed> $attributes = dict[];
-  private vec<XHPChild> $children = vec[];
+  private vec<\XHPChild> $children = vec[];
   private dict<string, mixed> $context = dict[];
 
   protected function init(): void {
@@ -36,7 +38,7 @@ abstract xhp class x:node extends :xhp {
    */
   final public function __construct(
     KeyedTraversable<string, mixed> $attributes,
-    Traversable<XHPChild> $children,
+    Traversable<\XHPChild> $children,
     dynamic ...$debug_info
   ) {
     parent::__construct($attributes, $children);
@@ -47,7 +49,7 @@ abstract xhp class x:node extends :xhp {
     foreach ($attributes as $key => $value) {
       if (self::isSpreadKey($key)) {
         invariant(
-          $value is :x:node,
+          $value is node,
           "Only XHP can be used with an attribute spread operator",
         );
         $this->spreadElementImpl($value);
@@ -56,7 +58,7 @@ abstract xhp class x:node extends :xhp {
       }
     }
 
-    if (:xhp::isChildValidationEnabled()) {
+    if (xhp::isChildValidationEnabled()) {
       if (C\count($debug_info) >= 2) {
         $this->source = $debug_info[0].':'.$debug_info[1];
       } else {
@@ -82,12 +84,12 @@ abstract xhp class x:node extends :xhp {
       foreach ($child as $c) {
         $this->appendChild($c);
       }
-    } else if ($child is :x:frag) {
+    } else if ($child is frag) {
       foreach ($child->getChildren() as $new_child) {
         $this->children[] = $new_child;
       }
     } else if ($child !== null) {
-      assert($child is XHPChild);
+      assert($child is \XHPChild);
       $this->children[] = $child;
     }
     return $this;
@@ -98,12 +100,12 @@ abstract xhp class x:node extends :xhp {
    *
    * @param $children  single child or a Traversable of children
    */
-  final public function replaceChildren(XHPChild ...$children): this {
+  final public function replaceChildren(\XHPChild ...$children): this {
     invariant(!$this->__isRendered, "Can't appendChild after render");
     // This function has been micro-optimized
     $new_children = vec[];
     foreach ($children as $xhp) {
-      if ($xhp is :x:frag) {
+      if ($xhp is frag) {
         foreach ($xhp->children as $child) {
           $new_children[] = $child;
         }
@@ -111,12 +113,12 @@ abstract xhp class x:node extends :xhp {
         $new_children[] = $xhp;
       } else {
         foreach ($xhp as $element) {
-          if ($element is :x:frag) {
+          if ($element is frag) {
             foreach ($element->children as $child) {
               $new_children[] = $child;
             }
           } else if ($element !== null) {
-            $new_children[] = $element as XHPChild;
+            $new_children[] = $element as \XHPChild;
           }
         }
       }
@@ -131,7 +133,7 @@ abstract xhp class x:node extends :xhp {
    *
    * @param $selector   tag name or category (optional)
    */
-  final public function getChildren(?string $selector = null): vec<XHPChild> {
+  final public function getChildren(?string $selector = null): vec<\XHPChild> {
     if ($selector is null || $selector === '') {
       return $this->children;
     }
@@ -140,14 +142,14 @@ abstract xhp class x:node extends :xhp {
     if ($selector[0] == '%') {
       $selector = Str\slice($selector, 1);
       foreach ($this->children as $child) {
-        if ($child is :xhp && $child->categoryOf($selector)) {
+        if ($child is xhp && $child->categoryOf($selector)) {
           $children[] = $child;
         }
       }
     } else {
-      $selector = :xhp::element2class($selector);
+      $selector = xhp::element2class($selector);
       foreach ($this->children as $child) {
-        if (is_a($child, $selector, /* allow strings = */ true)) {
+        if (\is_a($child, $selector, /* allow strings = */ true)) {
           $children[] = $child;
         }
       }
@@ -165,20 +167,20 @@ abstract xhp class x:node extends :xhp {
    * @return           the first child node (with the given selector),
    *                       null if there are no (matching) children
    */
-  final public function getFirstChild(?string $selector = null): ?XHPChild {
+  final public function getFirstChild(?string $selector = null): ?\XHPChild {
     if ($selector === null) {
       return $this->children[0] ?? null;
     } else if ($selector[0] == '%') {
-      $selector = substr($selector, 1);
+      $selector = \substr($selector, 1);
       foreach ($this->children as $child) {
-        if ($child is :xhp && $child->categoryOf($selector)) {
+        if ($child is xhp && $child->categoryOf($selector)) {
           return $child;
         }
       }
     } else {
-      $selector = :xhp::element2class($selector);
+      $selector = xhp::element2class($selector);
       foreach ($this->children as $child) {
-        if (is_a($child, $selector, /* allow strings = */ true)) {
+        if (\is_a($child, $selector, /* allow strings = */ true)) {
           return $child;
         }
       }
@@ -194,7 +196,7 @@ abstract xhp class x:node extends :xhp {
    * @return           the last child node (with the given selector),
    *                       null if there are no (matching) children
    */
-  final public function getLastChild(?string $selector = null): ?XHPChild {
+  final public function getLastChild(?string $selector = null): ?\XHPChild {
     return $this->getChildren($selector) |> C\last($$);
   }
 
@@ -213,14 +215,14 @@ abstract xhp class x:node extends :xhp {
       return $this->attributes[$attr];
     }
 
-    if (!ReflectionXHPAttribute::IsSpecial($attr)) {
+    if (!\ReflectionXHPAttribute::IsSpecial($attr)) {
       // Get the declaration
       $decl = static::__xhpReflectionAttribute($attr);
 
       if ($decl === null) {
-        throw new XHPAttributeNotSupportedException($this, $attr);
+        throw new \Facebook\XHP\AttributeNotSupportedException($this, $attr);
       } else if ($decl->isRequired()) {
-        throw new XHPAttributeRequiredException($this, $attr);
+        throw new \Facebook\XHP\AttributeRequiredException($this, $attr);
       } else {
         return $decl->getDefaultValue();
       }
@@ -231,17 +233,17 @@ abstract xhp class x:node extends :xhp {
 
   final public static function __xhpReflectionAttribute(
     string $attr,
-  ): ?ReflectionXHPAttribute {
+  ): ?\ReflectionXHPAttribute {
     return static::__xhpReflectionAttributes()[$attr] ?? null;
   }
 
   <<__MemoizeLSB>>
   final public static function __xhpReflectionAttributes(
-  ): dict<string, ReflectionXHPAttribute> {
+  ): dict<string, \ReflectionXHPAttribute> {
     $decl = static::__xhpAttributeDeclaration();
     return Dict\map_with_key(
       $decl,
-      ($name, $attr_decl) ==> new ReflectionXHPAttribute($name, $attr_decl),
+      ($name, $attr_decl) ==> new \ReflectionXHPAttribute($name, $attr_decl),
     );
   }
 
@@ -256,9 +258,9 @@ abstract xhp class x:node extends :xhp {
 
   <<__MemoizeLSB>>
   final public static function __xhpReflectionChildrenDeclaration(
-  ): ReflectionXHPChildrenDeclaration {
-    return new ReflectionXHPChildrenDeclaration(
-      :xhp::class2element(static::class),
+  ): \ReflectionXHPChildrenDeclaration {
+    return new \ReflectionXHPChildrenDeclaration(
+      xhp::class2element(static::class),
       static::__legacySerializedXHPChildrenDeclaration(),
     );
   }
@@ -286,7 +288,7 @@ abstract xhp class x:node extends :xhp {
    * in the constructor.
    */
   private static function isSpreadKey(string $key): bool {
-    return substr($key, 0, strlen(:xhp::SPREAD_PREFIX)) === :xhp::SPREAD_PREFIX;
+    return Str\starts_with($key, xhp::SPREAD_PREFIX);
   }
 
   /**
@@ -298,9 +300,7 @@ abstract xhp class x:node extends :xhp {
    *
    * Defaults from $xhp are copied as well, if they are present.
    */
-  protected final function spreadElementImpl(
-    :x:node $element,
-  ): void {
+  protected final function spreadElementImpl(node $element): void {
     $attrs = $element::__xhpReflectionAttributes()
       |> Dict\filter($$, $attr ==> $attr->hasDefaultValue())
       |> Dict\map($$, $attr ==> $attr->getDefaultValue())
@@ -309,7 +309,7 @@ abstract xhp class x:node extends :xhp {
       if (
         $value === null ||
         !(
-          ReflectionXHPAttribute::IsSpecial($attr_name) ||
+          \ReflectionXHPAttribute::IsSpecial($attr_name) ||
           (static::__xhpReflectionAttribute($attr_name) !== null)
         )
       ) {
@@ -460,7 +460,7 @@ abstract xhp class x:node extends :xhp {
     }
   }
 
-  abstract protected function __flushSubtree(): Awaitable<:x:primitive>;
+  abstract protected function __flushSubtree(): Awaitable<primitive>;
 
   /**
    * Defined in elements by the `attribute` keyword. The declaration is simple.
@@ -504,12 +504,12 @@ abstract xhp class x:node extends :xhp {
   protected function validateChildren(): void {
     $decl = self::__xhpReflectionChildrenDeclaration();
     $type = $decl->getType();
-    if ($type === XHPChildrenDeclarationType::ANY_CHILDREN) {
+    if ($type === \XHPChildrenDeclarationType::ANY_CHILDREN) {
       return;
     }
-    if ($type === XHPChildrenDeclarationType::NO_CHILDREN) {
+    if ($type === \XHPChildrenDeclarationType::NO_CHILDREN) {
       if ($this->children) {
-        throw new XHPInvalidChildrenException($this, 0);
+        throw new \Facebook\XHP\InvalidChildrenException($this, 0);
       } else {
         return;
       }
@@ -519,34 +519,34 @@ abstract xhp class x:node extends :xhp {
       0,
     );
     if (!$ret || $ii < C\count($this->children)) {
-      if (($this->children[$ii] ?? null) is XHPAlwaysValidChild) {
+      if (($this->children[$ii] ?? null) is \Facebook\XHP\AlwaysValidChild) {
         return;
       }
-      throw new XHPInvalidChildrenException($this, $ii);
+      throw new \Facebook\XHP\InvalidChildrenException($this, $ii);
     }
   }
 
   final private function validateChildrenExpression(
-    ReflectionXHPChildrenExpression $expr,
+    \ReflectionXHPChildrenExpression $expr,
     int $index,
   ): (bool, int) {
     switch ($expr->getType()) {
-      case XHPChildrenExpressionType::SINGLE:
+      case \XHPChildrenExpressionType::SINGLE:
         // Exactly once -- :fb_thing
         return $this->validateChildrenRule($expr, $index);
-      case XHPChildrenExpressionType::ANY_NUMBER:
+      case \XHPChildrenExpressionType::ANY_NUMBER:
         // Zero or more times -- :fb_thing*
         do {
           list($ret, $index) = $this->validateChildrenRule($expr, $index);
         } while ($ret);
         return tuple(true, $index);
 
-      case XHPChildrenExpressionType::ZERO_OR_ONE:
+      case \XHPChildrenExpressionType::ZERO_OR_ONE:
         // Zero or one times -- :fb_thing?
         list($_, $index) = $this->validateChildrenRule($expr, $index);
         return tuple(true, $index);
 
-      case XHPChildrenExpressionType::ONE_OR_MORE:
+      case \XHPChildrenExpressionType::ONE_OR_MORE:
         // One or more times -- :fb_thing+
         list($ret, $index) = $this->validateChildrenRule($expr, $index);
         if (!$ret) {
@@ -557,7 +557,7 @@ abstract xhp class x:node extends :xhp {
         } while ($ret);
         return tuple(true, $index);
 
-      case XHPChildrenExpressionType::SUB_EXPR_SEQUENCE:
+      case \XHPChildrenExpressionType::SUB_EXPR_SEQUENCE:
         // Specific order -- :fb_thing, :fb_other_thing
         $oindex = $index;
         list($sub_expr_1, $sub_expr_2) = $expr->getSubExpressions();
@@ -576,7 +576,7 @@ abstract xhp class x:node extends :xhp {
         }
         return tuple(false, $oindex);
 
-      case XHPChildrenExpressionType::SUB_EXPR_DISJUNCTION:
+      case \XHPChildrenExpressionType::SUB_EXPR_DISJUNCTION:
         // Either or -- :fb_thing | :fb_other_thing
         $oindex = $index;
         list($sub_expr_1, $sub_expr_2) = $expr->getSubExpressions();
@@ -598,39 +598,39 @@ abstract xhp class x:node extends :xhp {
   }
 
   final private function validateChildrenRule(
-    ReflectionXHPChildrenExpression $expr,
+    \ReflectionXHPChildrenExpression $expr,
     int $index,
   ): (bool, int) {
     switch ($expr->getConstraintType()) {
-      case XHPChildrenConstraintType::ANY:
+      case \XHPChildrenConstraintType::ANY:
         if (C\contains_key($this->children, $index)) {
           return tuple(true, $index + 1);
         }
         return tuple(false, $index);
 
-      case XHPChildrenConstraintType::PCDATA:
+      case \XHPChildrenConstraintType::PCDATA:
         if (
           C\contains_key($this->children, $index) &&
-          !($this->children[$index] is :xhp)
+          !($this->children[$index] is xhp)
         ) {
           return tuple(true, $index + 1);
         }
         return tuple(false, $index);
 
-      case XHPChildrenConstraintType::ELEMENT:
+      case \XHPChildrenConstraintType::ELEMENT:
         $class = $expr->getConstraintString();
         if (
           C\contains_key($this->children, $index) &&
-          is_a($this->children[$index], $class, true)
+          \is_a($this->children[$index], $class, true)
         ) {
           return tuple(true, $index + 1);
         }
         return tuple(false, $index);
 
-      case XHPChildrenConstraintType::CATEGORY:
+      case \XHPChildrenConstraintType::CATEGORY:
         if (
           !C\contains_key($this->children, $index) ||
-          !($this->children[$index] is :xhp)
+          !($this->children[$index] is xhp)
         ) {
           return tuple(false, $index);
         }
@@ -638,14 +638,14 @@ abstract xhp class x:node extends :xhp {
           |> Str\replace($$, '__', ':')
           |> Str\replace($$, '_', '-');
         $child = $this->children[$index];
-        assert($child is :xhp);
+        assert($child is xhp);
         $categories = $child->__xhpCategoryDeclaration();
         if (($categories[$category] ?? 0) === 0) {
           return tuple(false, $index);
         }
         return tuple(true, $index + 1);
 
-      case XHPChildrenConstraintType::SUB_EXPR:
+      case \XHPChildrenConstraintType::SUB_EXPR:
         return $this->validateChildrenExpression(
           $expr->getSubExpression(),
           $index,
@@ -673,18 +673,18 @@ abstract xhp class x:node extends :xhp {
   final public function __getChildrenDescription(): string {
     $desc = varray[];
     foreach ($this->children as $child) {
-      if ($child is :xhp) {
-        $tmp = ':'.:xhp::class2element(get_class($child));
+      if ($child is xhp) {
+        $tmp = ':'.xhp::class2element(\get_class($child));
         $categories = $child->__xhpCategoryDeclaration();
         if (C\count($categories) > 0) {
-          $tmp .= '[%'.implode(',%', array_keys($categories)).']';
+          $tmp .= '[%'.Str\join(Vec\keys($categories), ',%').']';
         }
         $desc[] = $tmp;
       } else {
         $desc[] = 'pcdata';
       }
     }
-    return implode(',', $desc);
+    return Str\join($desc, ',');
   }
 
   final public function categoryOf(string $c): bool {
@@ -693,7 +693,7 @@ abstract xhp class x:node extends :xhp {
       return true;
     }
     // XHP parses the category string
-    $c = str_replace(varray[':', '-'], varray['__', '_'], $c);
+    $c = \str_replace(varray[':', '-'], varray['__', '_'], $c);
     return ($categories[$c] ?? null) !== null;
   }
 }

--- a/src/core/Primitive.hack
+++ b/src/core/Primitive.hack
@@ -7,6 +7,8 @@
  *
  */
 
+namespace Facebook\XHP\Elements\Core;
+
 use namespace HH\Lib\Dict;
 
 /**
@@ -15,9 +17,7 @@ use namespace HH\Lib\Dict;
  * needs to directly implement stringify(). All other elements should subclass
  * from :x:element.
  */
-abstract xhp class x:primitive
-  extends :x:node
-  implements XHPRoot {
+abstract xhp class primitive extends node implements \XHPRoot {
   abstract protected function stringifyAsync(): Awaitable<string>;
 
   final public async function toStringAsync(): Awaitable<string> {
@@ -29,7 +29,7 @@ abstract xhp class x:primitive
     $children = $this->getChildren();
     $awaitables = dict[];
     foreach ($children as $idx => $child) {
-      if ($child is :x:node) {
+      if ($child is node) {
         $child->__transferContext($this->getAllContexts());
         $awaitables[$idx] = $child->__flushSubtree();
       }
@@ -43,9 +43,9 @@ abstract xhp class x:primitive
     $this->replaceChildren($children);
   }
 
-  final protected async function __flushSubtree(): Awaitable<:x:primitive> {
+  final protected async function __flushSubtree(): Awaitable<primitive> {
     await $this->__flushElementChildren();
-    if (:xhp::isChildValidationEnabled()) {
+    if (xhp::isChildValidationEnabled()) {
       $this->validateChildren();
     }
     return $this;

--- a/src/core/UnsafeAttributeValue.hack
+++ b/src/core/UnsafeAttributeValue.hack
@@ -7,6 +7,8 @@
  *
  */
 
+namespace Facebook\XHP;
+
 /**
  * INCREDIBLY DANGEROUS: Marks an object as being able to provide an HTML
  * string.
@@ -16,7 +18,7 @@
  *
  * This must be used via `forceAttribute()`.
  */
-abstract class XHPUnsafeAttributeValue {
+abstract class UnsafeAttributeValue {
   abstract public function toHTMLString(): string;
 
   final public function __toString(): string {

--- a/src/core/UnsafeRenderable.hack
+++ b/src/core/UnsafeRenderable.hack
@@ -7,13 +7,16 @@
  *
  */
 
+namespace Facebook\XHP;
+
 /**
- * INCREDIBLY DANGEROUS: Marks an object as a valid child of *any* element,
- * ignoring any child rules.
+ * INCREDIBLY DANGEROUS: Marks an object as being able to provide an HTML
+ * string.
  *
  * This is useful when migrating to XHP as it allows you to embed non-XHP
- * content, usually in combination with XHPUnsafeRenderable; see MIGRATING.md
+ * content, usually in combination with XHPAlwaysValidChild; see MIGRATING.md
  * for more information.
  */
-interface XHPAlwaysValidChild {
+interface UnsafeRenderable extends \XHPChild {
+  public function toHTMLStringAsync(): Awaitable<string>;
 }

--- a/src/core/XHPRoot.hack
+++ b/src/core/XHPRoot.hack
@@ -7,6 +7,9 @@
  *
  */
 
+// Leaving this in the root namespace for consistency with the builtin
+// XHPChild namespace
+
 interface XHPRoot extends XHPChild {
-  require extends :x:node;
+  require extends \Facebook\XHP\Elements\Core\node;
 }

--- a/src/exceptions/AttributeNotSupportedException.hack
+++ b/src/exceptions/AttributeNotSupportedException.hack
@@ -7,14 +7,18 @@
  *
  */
 
-class XHPAttributeNotSupportedException extends XHPException {
-  public function __construct(:xhp $that, string $attr) {
+namespace Facebook\XHP;
+
+use namespace Facebook\XHP\Elements\Core as x;
+
+class AttributeNotSupportedException extends namespace\Exception {
+  public function __construct(x\xhp $that, string $attr) {
     parent::__construct(
       'Attribute "'.
       $attr.
       '" is not supported in class '.
       '"'.
-      XHPException::getElementName($that).
+      self::getElementName($that).
       '"'.
       "\n\n".
       $that->source.

--- a/src/exceptions/AttributeRequiredException.hack
+++ b/src/exceptions/AttributeRequiredException.hack
@@ -7,14 +7,18 @@
  *
  */
 
-class XHPAttributeRequiredException extends XHPException {
-  public function __construct(:xhp $that, string $attr) {
+namespace Facebook\XHP;
+
+use namespace Facebook\XHP\Elements\Core as x;
+
+class AttributeRequiredException extends namespace\Exception {
+  public function __construct(x\xhp $that, string $attr) {
     parent::__construct(
       'Required attribute `'.
       $attr.
       '` was not specified in element '.
       '`'.
-      XHPException::getElementName($that).
+      self::getElementName($that).
       "`.\n\n".
       $that->source,
     );

--- a/src/exceptions/ClassException.hack
+++ b/src/exceptions/ClassException.hack
@@ -7,11 +7,15 @@
  *
  */
 
-class XHPClassException extends XHPException {
-  public function __construct(:xhp $that, string $msg) {
+namespace Facebook\XHP;
+
+use namespace Facebook\XHP\Elements\Core as x;
+
+class ClassException extends namespace\Exception {
+  public function __construct(x\xhp $that, string $msg) {
     parent::__construct(
       'Exception in class `'.
-      XHPException::getElementName($that).
+      self::getElementName($that).
       "`\n\n".
       "$that->source\n\n".
       $msg,

--- a/src/exceptions/CoreRenderException.hack
+++ b/src/exceptions/CoreRenderException.hack
@@ -7,13 +7,17 @@
  *
  */
 
-class XHPCoreRenderException extends XHPException {
-  public function __construct(:xhp $that, mixed $rend) {
+namespace Facebook\XHP;
+
+use namespace Facebook\XHP\Elements\Core as x;
+
+class CoreRenderException extends namespace\Exception {
+  public function __construct(x\xhp $that, mixed $rend) {
     parent::__construct(
       ':x:element::render must reduce an object to an :x:primitive, but `'.
-      :xhp::class2element(get_class($that)).
+      x\xhp::class2element(\get_class($that)).
       '` reduced into `'.
-      gettype($rend).
+      \gettype($rend).
       "`.\n\n".
       $that->source,
     );

--- a/src/exceptions/Exception.hack
+++ b/src/exceptions/Exception.hack
@@ -7,13 +7,17 @@
  *
  */
 
-class XHPException extends Exception {
-  protected static function getElementName(:xhp $that): string {
-    $name = get_class($that);
-    if (substr($name, 0, 4) !== 'xhp_') {
-      return $name;
-    } else {
-      return :xhp::class2element($name);
+namespace Facebook\XHP;
+
+use namespace Facebook\XHP\Elements\Core as x;
+use namespace HH\Lib\Str;
+
+class Exception extends \Exception {
+  protected static function getElementName(x\xhp $that): string {
+    $name = \get_class($that);
+    if (Str\starts_with($name, 'xhp_')) {
+      return x\xhp::class2element($name);
     }
+    return $name;
   }
 }

--- a/src/exceptions/InvalidChildrenException.hack
+++ b/src/exceptions/InvalidChildrenException.hack
@@ -7,11 +7,16 @@
  *
  */
 
-class XHPInvalidChildrenException extends XHPException {
-  public function __construct(:x:node $that, int $index) {
+
+namespace Facebook\XHP;
+
+use namespace Facebook\XHP\Elements\Core as x;
+
+class InvalidChildrenException extends namespace\Exception {
+  public function __construct(x\node $that, int $index) {
     parent::__construct(
       'Element `'.
-      XHPException::getElementName($that).
+      self::getElementName($that).
       '` was rendered with '.
       "invalid children.\n\n".
       "$that->source\n\n".

--- a/src/exceptions/RenderArrayException.hack
+++ b/src/exceptions/RenderArrayException.hack
@@ -7,5 +7,7 @@
  *
  */
 
-class XHPRenderArrayException extends XHPException {
+namespace Facebook\XHP;
+
+class RenderArrayException extends namespace\Exception {
 }

--- a/src/html/Element.hack
+++ b/src/html/Element.hack
@@ -7,6 +7,7 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use namespace HH\Lib\{Str, Vec};
 
 /**
@@ -15,7 +16,7 @@ use namespace HH\Lib\{Str, Vec};
  * close to spec as possible. Facebook-specific extensions should go into their
  * own elements.
  */
-abstract xhp class xhp:html_element extends :x:primitive {
+abstract xhp class xhp:html_element extends x\primitive {
   use XHPHTMLHelpers;
 
   // enum { 'true', 'false' } attributes: these are actually tri-state -
@@ -119,7 +120,7 @@ abstract xhp class xhp:html_element extends :x:primitive {
         if ($val === true) {
           $buf .= ' '.htmlspecialchars($key);
         } else {
-          if ($val is XHPUnsafeAttributeValue) {
+          if ($val is \Facebook\XHP\UnsafeAttributeValue) {
             $val_str = $val->toHTMLString();
           } else {
             $val_str = htmlspecialchars((string)$val, ENT_COMPAT);
@@ -136,7 +137,7 @@ abstract xhp class xhp:html_element extends :x:primitive {
     $buf = $this->renderBaseAttrs().'>';
     $buf .= await Vec\map_async(
       $this->getChildren(),
-      async $child ==> await :xhp::renderChildAsync($child),
+      async $child ==> await x\xhp::renderChildAsync($child),
     )
       |> Str\join($$, '');
     $buf .= '</'.$this->tagName.'>';

--- a/src/html/HasXHPHTMLHelpers.hack
+++ b/src/html/HasXHPHTMLHelpers.hack
@@ -7,8 +7,10 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
+
 interface HasXHPHTMLHelpers {
-  require extends :x:node;
+  require extends x\node;
 
   public function addClass(string $class): this;
   public function conditionClass(bool $cond, string $class): this;

--- a/src/html/RawPcdataElement.hack
+++ b/src/html/RawPcdataElement.hack
@@ -25,7 +25,7 @@ abstract xhp class xhp:raw_pcdata_element extends :xhp:pcdata_element {
     $buf = $this->renderBaseAttrs().'>';
     foreach ($this->getChildren() as $child) {
       if (!($child is string)) {
-        throw new XHPClassException($this, 'Child must be a string');
+        throw new \Facebook\XHP\ClassException($this, 'Child must be a string');
       }
       $buf .= $child;
     }

--- a/src/html/XHPAttributeClobbering_DEPRECATED.hack
+++ b/src/html/XHPAttributeClobbering_DEPRECATED.hack
@@ -7,13 +7,12 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use namespace Facebook\XHP\_Private;
 use namespace HH\Lib\{C, Dict};
 
 interface HasXHPAttributeClobbering_DEPRECATED extends HasXHPHTMLHelpers {
-  public function transferAttributesToRenderedRoot(
-    :x:node $root,
-  ): void;
+  public function transferAttributesToRenderedRoot(x\node $root): void;
 }
 
 /*
@@ -24,7 +23,7 @@ interface HasXHPAttributeClobbering_DEPRECATED extends HasXHPHTMLHelpers {
  */
 trait XHPAttributeClobbering_DEPRECATED
   implements HasXHPAttributeClobbering_DEPRECATED {
-  require extends :x:node;
+  require extends x\node;
 
   use XHPHTMLHelpers;
 
@@ -32,7 +31,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * Copies all attributes that are set on $this and valid on $target to
    * $target.
    */
-  final public function copyAllAttributes(:x:node $target): void {
+  final public function copyAllAttributes(x\node $target): void {
     $this->transferAttributesImpl($target, keyset[]);
   }
 
@@ -40,9 +39,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * Copies only the non-HTML attributes that are set on $this and valid on
    * $target to $target.
    */
-  final public function copyCustomAttributes(
-    :x:node $target,
-  ): void {
+  final public function copyCustomAttributes(x\node $target): void {
     $this->transferAttributesImpl($target);
   }
 
@@ -51,7 +48,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * valid on $target to $target.
    */
   final public function copyAttributesExcept(
-    :x:node $target,
+    x\node $target,
     keyset<string> $ignore,
   ): void {
     $this->transferAttributesImpl($target, $ignore);
@@ -61,9 +58,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * Transfers all attributes that are set on $this and valid on $target to
    * $target.
    */
-  final public function transferAllAttributes(
-    :x:node $target,
-  ): void {
+  final public function transferAllAttributes(x\node $target): void {
     $this->transferAttributesImpl($target, keyset[]);
   }
 
@@ -71,9 +66,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * Transfers only the non-HTML attributes that are set on $this and valid on
    * $target to $target.
    */
-  final public function transferCustomAttributes(
-    :x:node $target,
-  ): void {
+  final public function transferCustomAttributes(x\node $target): void {
     $this->transferAttributesImpl($target, null);
   }
 
@@ -83,7 +76,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * $this.
    */
   final public function transferAttributesExcept(
-    :x:node $target,
+    x\node $target,
     keyset<string> $ignore,
   ): void {
     $this->transferAttributesImpl($target, $ignore);
@@ -94,7 +87,7 @@ trait XHPAttributeClobbering_DEPRECATED
    * directly. Instead, use one of the transfer/copy flavors above.
    */
   final private function transferAttributesImpl(
-    :x:node $target,
+    x\node $target,
     ?keyset<string> $ignore = null,
     bool $remove = false,
   ): void {
@@ -120,9 +113,7 @@ trait XHPAttributeClobbering_DEPRECATED
     return keyset['class'];
   }
 
-  final public function transferAttributesToRenderedRoot(
-    :x:node $root,
-  ): void {
+  final public function transferAttributesToRenderedRoot(x\node $root): void {
     $attributes = $this->getAttributes();
 
     // We want to append classes to the root node, instead of replace them,

--- a/src/html/XHPHTMLHelpers.hack
+++ b/src/html/XHPHTMLHelpers.hack
@@ -7,9 +7,10 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 
 trait XHPHTMLHelpers implements HasXHPHTMLHelpers {
-  require extends :x:node;
+  require extends x\node;
 
   /*
    * Appends a string to the "class" attribute (space separated).

--- a/src/html/tags/c/ConditionalComment.hack
+++ b/src/html/tags/c/ConditionalComment.hack
@@ -7,6 +7,8 @@
  *
  */
 
+
+use namespace Facebook\XHP\Elements\Core as x;
 use namespace HH\Lib\{Str, Vec};
 
 /**
@@ -15,13 +17,13 @@ use namespace HH\Lib\{Str, Vec};
  */
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-xhp class x:conditional_comment extends :x:primitive {
+xhp class x:conditional_comment extends x\primitive {
   use XHPChildValidation;
   attribute string if @required;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyNumberOf(
-      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\ofType<:xhp>()),
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\ofType<x\xhp>()),
     );
   }
 
@@ -31,7 +33,7 @@ xhp class x:conditional_comment extends :x:primitive {
     $html = '<!--[if '.$this->:if.']>';
     $html .= await Vec\map_async(
       $this->getChildren(),
-      async $child ==> await :xhp::renderChildAsync($child),
+      async $child ==> await x\xhp::renderChildAsync($child),
     )
       |> Str\join($$, '');
     $html .= '<![endif]-->';

--- a/src/html/tags/d/Doctype.hack
+++ b/src/html/tags/d/Doctype.hack
@@ -7,15 +7,16 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use namespace HH\Lib\C;
+
+use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 /**
  * Render an <html /> element within a DOCTYPE, XHP has chosen to only support
  * the HTML5 doctype.
  */
-use namespace Facebook\XHP\ChildValidation as XHPChild;
-
-xhp class x:doctype extends :x:primitive {
+xhp class x:doctype extends x\primitive {
   use XHPChildValidation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
@@ -25,6 +26,6 @@ xhp class x:doctype extends :x:primitive {
 
   protected async function stringifyAsync(): Awaitable<string> {
     return '<!DOCTYPE html>'.
-      (await :xhp::renderChildAsync(C\onlyx($this->getChildren())));
+      (await x\xhp::renderChildAsync(C\onlyx($this->getChildren())));
   }
 }

--- a/src/reflection/ReflectionXHPChildrenDeclaration.hack
+++ b/src/reflection/ReflectionXHPChildrenDeclaration.hack
@@ -8,6 +8,7 @@
  */
 
 use type Facebook\TypeAssert\IncorrectTypeException;
+use namespace Facebook\XHP\Elements\Core as x;
 use namespace Facebook\TypeSpec;
 
 enum XHPChildrenDeclarationType: int {
@@ -59,7 +60,7 @@ class ReflectionXHPChildrenDeclaration {
 
     throw new Exception(
       "Tried to get child expression for XHP class ".
-      :xhp::class2element(get_class($this->context)).
+      x\xhp::class2element(get_class($this->context)).
       ", but it does not have an expressions.",
     );
   }
@@ -95,7 +96,7 @@ class ReflectionXHPChildrenExpression {
       $type === XHPChildrenExpressionType::SUB_EXPR_SEQUENCE ||
         $type === XHPChildrenExpressionType::SUB_EXPR_DISJUNCTION,
       'Only disjunctions and sequences have two sub-expressions - in %s',
-      :xhp::class2element(get_class($this->context)),
+      x\xhp::class2element(get_class($this->context)),
     );
     try {
       $sub_expr_1 = TypeSpec\dict_like_array(TypeSpec\int(), TypeSpec\mixed())
@@ -120,7 +121,7 @@ class ReflectionXHPChildrenExpression {
       $type !== XHPChildrenExpressionType::SUB_EXPR_SEQUENCE &&
         $type !== XHPChildrenExpressionType::SUB_EXPR_DISJUNCTION,
       'Disjunctions and sequences do not have a constraint type - in %s',
-      :xhp::class2element(get_class($this->context)),
+      x\xhp::class2element(get_class($this->context)),
     );
     return XHPChildrenConstraintType::assert($this->data[1]);
   }
@@ -132,7 +133,7 @@ class ReflectionXHPChildrenExpression {
       $type === XHPChildrenConstraintType::ELEMENT ||
         $type === XHPChildrenConstraintType::CATEGORY,
       'Only element and category constraints have string data - in %s',
-      :xhp::class2element(get_class($this->context)),
+      x\xhp::class2element(get_class($this->context)),
     );
     $data = $this->data[2];
     invariant($data is string, 'Expected string data');
@@ -196,7 +197,7 @@ class ReflectionXHPChildrenExpression {
         return 'pcdata';
 
       case XHPChildrenConstraintType::ELEMENT:
-        return ':'.:xhp::class2element($this->getConstraintString());
+        return ':'.x\xhp::class2element($this->getConstraintString());
 
       case XHPChildrenConstraintType::CATEGORY:
         return '%'.$this->getConstraintString();

--- a/src/reflection/ReflectionXHPClass.hack
+++ b/src/reflection/ReflectionXHPClass.hack
@@ -7,12 +7,11 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use namespace HH\Lib\C;
 
 class ReflectionXHPClass {
-  public function __construct(
-    private classname<:x:node> $className,
-  ) {
+  public function __construct(private classname<x\node> $className) {
     invariant(
       class_exists($this->className),
       'Invalid class name: %s',
@@ -24,12 +23,12 @@ class ReflectionXHPClass {
     return new ReflectionClass($this->getClassName());
   }
 
-  public function getClassName(): classname<:x:node> {
+  public function getClassName(): classname<x\node> {
     return $this->className;
   }
 
   public function getElementName(): string {
-    return :xhp::class2element($this->getClassName());
+    return x\xhp::class2element($this->getClassName());
   }
 
   public function getChildren(): ReflectionXHPChildrenDeclaration {

--- a/tests/AsyncTest.hack
+++ b/tests/AsyncTest.hack
@@ -7,32 +7,33 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use namespace HH\Lib\Math;
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 
-xhp class async:test extends :x:element {
+xhp class async:test extends x\element {
 
   protected async function renderAsync(): Awaitable<XHPRoot> {
     return <div>{$this->getChildren()}</div>;
   }
 }
 
-xhp class test:xfrag_wrap extends :x:element {
+xhp class test:xfrag_wrap extends x\element {
 
   protected async function renderAsync(): Awaitable<XHPRoot> {
     return <x:frag>{$this->getChildren()}</x:frag>;
   }
 }
 
-xhp class test:async_xfrag_wrap extends :x:element {
+xhp class test:async_xfrag_wrap extends x\element {
 
   protected async function renderAsync(): Awaitable<XHPRoot> {
     return <x:frag>{$this->getChildren()}</x:frag>;
   }
 }
 
-xhp class async:par_test extends :x:element {
+xhp class async:par_test extends x\element {
 
   attribute string label @required;
 
@@ -83,7 +84,7 @@ class AsyncTest extends Facebook\HackTest\HackTest {
     expect(await $xhp->toStringAsync())->toEqual('<div><b>BE BOLD</b></div>');
   }
 
-  public function parallelizationContainersProvider(): varray<varray<:xhp>> {
+  public function parallelizationContainersProvider(): varray<varray<x\xhp>> {
     return varray[
       varray[<test:xfrag_wrap />],
       varray[<test:async_xfrag_wrap />],
@@ -92,7 +93,7 @@ class AsyncTest extends Facebook\HackTest\HackTest {
 
   <<DataProvider('parallelizationContainersProvider')>>
   public async function testParallelization(
-    :x:element $container,
+    x\element $container,
   ): Awaitable<void> {
     :async:par_test::$log = vec[];
 

--- a/tests/AttributesTest.hack
+++ b/tests/AttributesTest.hack
@@ -7,11 +7,12 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use function Facebook\FBExpect\expect;
 use namespace HH\Lib\Vec;
 
 type TMyTestShape = shape('foo' => string, 'bar' => ?string);
-xhp class test:attribute_types extends :x:element {
+xhp class test:attribute_types extends x\element {
   attribute
     string mystring,
     bool mybool,
@@ -31,7 +32,7 @@ xhp class test:attribute_types extends :x:element {
   }
 }
 
-xhp class test:required_attributes extends :x:element {
+xhp class test:required_attributes extends x\element {
   attribute string mystring @required;
 
   protected async function renderAsync(): Awaitable<XHPRoot> {
@@ -39,7 +40,7 @@ xhp class test:required_attributes extends :x:element {
   }
 }
 
-xhp class test:default_attributes extends :x:element {
+xhp class test:default_attributes extends x\element {
   attribute string mystring = 'mydefault';
 
   protected async function renderAsync(): Awaitable<XHPRoot> {
@@ -47,7 +48,7 @@ xhp class test:default_attributes extends :x:element {
   }
 }
 
-xhp class test:callable_attribute extends :x:element {
+xhp class test:callable_attribute extends x\element {
   attribute
     /* HH_FIXME[2049]: callable is an invalid Hack type */
     callable foo; // unsupported in 2.0+
@@ -113,7 +114,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
     expect(() ==> {
       $x = <test:required_attributes />;
       expect($x->:mystring)->toBeNull();
-    })->toThrow(XHPAttributeRequiredException::class);
+    })->toThrow(Facebook\XHP\AttributeRequiredException::class);
   }
 
   public async function testProvidingDefaultAttributes(): Awaitable<void> {

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -7,10 +7,11 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use function Facebook\FBExpect\expect;
 use namespace HH\Lib\C;
 
-xhp class test:renders_primitive extends :x:element {
+xhp class test:renders_primitive extends x\element {
   protected async function renderAsync(): Awaitable<XHPRoot> {
     return <x:frag><div>123</div></x:frag>;
   }
@@ -58,11 +59,11 @@ class BasicsTest extends Facebook\HackTest\HackTest {
   }
 
   public async function testElement2Class(): Awaitable<void> {
-    expect(:xhp::element2class('div'))->toEqual(:div::class);
+    expect(x\xhp::element2class('div'))->toEqual(:div::class);
   }
 
   public async function testClass2Element(): Awaitable<void> {
-    expect(:xhp::class2element(:div::class))->toEqual('div');
+    expect(x\xhp::class2element(:div::class))->toEqual('div');
   }
 
   public async function testRendersPrimitive(): Awaitable<void> {

--- a/tests/ChildRuleTest.hack
+++ b/tests/ChildRuleTest.hack
@@ -7,11 +7,12 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-xhp class test:new_child_declaration_only extends :x:element {
+xhp class test:new_child_declaration_only extends x\element {
   use XHPChildValidation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
@@ -23,7 +24,7 @@ xhp class test:new_child_declaration_only extends :x:element {
   }
 }
 
-xhp class test:new_and_old_child_declarations extends :x:element {
+xhp class test:new_and_old_child_declarations extends x\element {
   // Providing all of these is invalid; for a migration consistency check, use
   // the XHPChildDeclarationConsistencyValidation trait instead.
   use XHPChildValidation;
@@ -36,7 +37,7 @@ xhp class test:new_and_old_child_declarations extends :x:element {
   }
 }
 
-xhp class test:old_child_declaration_only extends :x:element {
+xhp class test:old_child_declaration_only extends x\element {
   use XHPChildValidation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
@@ -49,7 +50,7 @@ xhp class test:old_child_declaration_only extends :x:element {
   }
 }
 
-xhp class test:any_children extends :x:element {
+xhp class test:any_children extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any();
@@ -60,7 +61,7 @@ xhp class test:any_children extends :x:element {
   }
 }
 
-xhp class test:no_children extends :x:element {
+xhp class test:no_children extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\empty();
@@ -71,7 +72,7 @@ xhp class test:no_children extends :x:element {
   }
 }
 
-xhp class test:single_child extends :x:element {
+xhp class test:single_child extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\ofType<:div>();
@@ -82,7 +83,7 @@ xhp class test:single_child extends :x:element {
   }
 }
 
-xhp class test:optional_child extends :x:element {
+xhp class test:optional_child extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\optional(XHPChild\ofType<:div>());
@@ -93,7 +94,7 @@ xhp class test:optional_child extends :x:element {
   }
 }
 
-xhp class test:any_number_of_child extends :x:element {
+xhp class test:any_number_of_child extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyNumberOf(XHPChild\ofType<:div>());
@@ -104,7 +105,7 @@ xhp class test:any_number_of_child extends :x:element {
   }
 }
 
-xhp class test:at_least_one_child extends :x:element {
+xhp class test:at_least_one_child extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\atLeastOneOf(XHPChild\ofType<:div>());
@@ -115,7 +116,7 @@ xhp class test:at_least_one_child extends :x:element {
   }
 }
 
-xhp class test:two_children extends :x:element {
+xhp class test:two_children extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(XHPChild\ofType<:div>(), XHPChild\ofType<:div>());
@@ -126,7 +127,7 @@ xhp class test:two_children extends :x:element {
   }
 }
 
-xhp class test:three_children extends :x:element {
+xhp class test:three_children extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(
@@ -142,7 +143,7 @@ xhp class test:three_children extends :x:element {
 }
 
 
-xhp class test:either_of_two_children extends :x:element {
+xhp class test:either_of_two_children extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(XHPChild\ofType<:div>(), XHPChild\ofType<:code>());
@@ -153,7 +154,7 @@ xhp class test:either_of_two_children extends :x:element {
   }
 }
 
-xhp class test:any_of_three_children extends :x:element {
+xhp class test:any_of_three_children extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(
@@ -169,7 +170,7 @@ xhp class test:any_of_three_children extends :x:element {
 }
 
 
-xhp class test:nested_rule extends :x:element {
+xhp class test:nested_rule extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\anyOf(
@@ -183,7 +184,7 @@ xhp class test:nested_rule extends :x:element {
   }
 }
 
-xhp class test:pcdata_child extends :x:element {
+xhp class test:pcdata_child extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\pcdata();
@@ -194,7 +195,7 @@ xhp class test:pcdata_child extends :x:element {
   }
 }
 
-xhp class test:category_child extends :x:element {
+xhp class test:category_child extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%flow');
@@ -205,7 +206,7 @@ xhp class test:category_child extends :x:element {
   }
 }
 
-xhp class test:has_comma_category extends :x:element {
+xhp class test:has_comma_category extends x\element {
   category %foo:bar;
 
   protected async function renderAsync(): Awaitable<XHPRoot> {
@@ -213,7 +214,7 @@ xhp class test:has_comma_category extends :x:element {
   }
 }
 
-xhp class test:needs_comma_category extends :x:element {
+xhp class test:needs_comma_category extends x\element {
   use XHPChildValidation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%foo:bar');
@@ -241,7 +242,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
     expect(async () ==> {
       $x = <test:no_children><div /></test:no_children>;
       await $x->toStringAsync();
-    })->toThrow(XHPInvalidChildrenException::class);
+    })->toThrow(Facebook\XHP\InvalidChildrenException::class);
   }
 
   public async function testSingleChild(): Awaitable<void> {
@@ -263,14 +264,11 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
   }
 
   <<DataProvider('toStringProvider')>>
-  public function testToString(
-    :x:node $elem,
-    string $expected,
-  ): void {
+  public function testToString(x\node $elem, string $expected): void {
     expect($elem->__getChildrenDeclaration())->toEqual($expected);
   }
 
-  public function toStringProvider(): vec<(:xhp, string)> {
+  public function toStringProvider(): vec<(x\xhp, string)> {
     return vec[
       tuple(<test:any_children />, 'any'),
       tuple(<test:no_children />, 'empty'),
@@ -298,7 +296,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
     ];
     foreach ($elems as $elem) {
       expect(async () ==> await $elem->toStringAsync())
-        ->toThrow(XHPInvalidChildrenException::class);
+        ->toThrow(Facebook\XHP\InvalidChildrenException::class);
     }
   }
 
@@ -316,7 +314,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       $exception = null;
       $elem->appendChild(<x:frag><div /><div /><div /><div /></x:frag>);
       expect(async () ==> await $elem->toStringAsync())
-        ->toThrow(XHPInvalidChildrenException::class);
+        ->toThrow(Facebook\XHP\InvalidChildrenException::class);
     }
   }
 
@@ -339,7 +337,9 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       } catch (Exception $e) {
         $exception = $e;
       }
-      expect($exception)->toBeInstanceOf(XHPInvalidChildrenException::class);
+      expect($exception)->toBeInstanceOf(
+        Facebook\XHP\InvalidChildrenException::class,
+      );
     }
   }
 
@@ -401,7 +401,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
     expect(async () ==> {
       $x = <div><test:at_least_one_child /></div>;
       await $x->toStringAsync();
-    })->toThrow(XHPInvalidChildrenException::class);
+    })->toThrow(Facebook\XHP\InvalidChildrenException::class);
   }
 
   public async function testNewChildDeclarations(): Awaitable<void> {
@@ -416,12 +416,12 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
     expect(
       async () ==> await (<test:new_child_declaration_only />)->toStringAsync(),
     )
-      ->toThrow(XHPInvalidChildrenException::class);
+      ->toThrow(Facebook\XHP\InvalidChildrenException::class);
     expect(
       async () ==> await (
         <test:new_child_declaration_only><p /></test:new_child_declaration_only>
       )->toStringAsync(),
-    )->toThrow(XHPInvalidChildrenException::class);
+    )->toThrow(Facebook\XHP\InvalidChildrenException::class);
   }
 
   public async function testOldChildDeclarations(): Awaitable<void> {
@@ -436,11 +436,11 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
     expect(
       async () ==> await (<test:old_child_declaration_only />)->toStringAsync(),
     )
-      ->toThrow(XHPInvalidChildrenException::class);
+      ->toThrow(Facebook\XHP\InvalidChildrenException::class);
     expect(
       async () ==> await (
         <test:old_child_declaration_only><p /></test:old_child_declaration_only>
       )->toStringAsync(),
-    )->toThrow(XHPInvalidChildrenException::class);
+    )->toThrow(Facebook\XHP\InvalidChildrenException::class);
   }
 }

--- a/tests/HackEnumAttributesTest.hack
+++ b/tests/HackEnumAttributesTest.hack
@@ -7,6 +7,7 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use function Facebook\FBExpect\expect;
 
 enum TestEnum: int {
@@ -14,7 +15,7 @@ enum TestEnum: int {
   DERP = 2;
 }
 
-xhp class test:hack_enum_attribute extends :x:element {
+xhp class test:hack_enum_attribute extends x\element {
   attribute TestEnum foo @required;
   protected async function renderAsync(): Awaitable<XHPRoot> {
     $foo = TestEnum::getNames()[$this->:foo];

--- a/tests/ReflectionTest.hack
+++ b/tests/ReflectionTest.hack
@@ -9,10 +9,11 @@
 
 use function Facebook\FBExpect\expect;
 
+use namespace Facebook\XHP\Elements\Core as x;
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 use namespace HH\Lib\Dict;
 
-xhp class test:for_reflection extends :x:element {
+xhp class test:for_reflection extends x\element {
   use XHPChildValidation;
   attribute
     string mystring @required,

--- a/tests/TestChildFlushing.hack
+++ b/tests/TestChildFlushing.hack
@@ -7,11 +7,12 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use function Facebook\FBExpect\expect;
 
 use type Facebook\HackTest\DataProvider;
 
-xhp class test:verbatim_root extends :x:element {
+xhp class test:verbatim_root extends x\element {
   attribute XHPRoot root @required;
 
   protected async function renderAsync(): Awaitable<XHPRoot> {
@@ -19,7 +20,7 @@ xhp class test:verbatim_root extends :x:element {
   }
 }
 
-xhp class test:verbatim_root:async extends :x:element {
+xhp class test:verbatim_root:async extends x\element {
 
   attribute XHPRoot root @required;
 
@@ -29,7 +30,7 @@ xhp class test:verbatim_root:async extends :x:element {
 }
 
 class XHPChildFlushTest extends Facebook\HackTest\HackTest {
-  public function xhpRootProvider(): vec<(:xhp, string)> {
+  public function xhpRootProvider(): vec<(x\xhp, string)> {
     return vec[
       tuple(<div />, '<div></div>'),
       tuple(<div><div /><div /></div>, '<div><div></div><div></div></div>'),

--- a/tests/UnsafeInterfacesTest.hack
+++ b/tests/UnsafeInterfacesTest.hack
@@ -7,12 +7,13 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use function Facebook\FBExpect\expect;
 
 // Please see MIGRATING.md for information on how these should be used in
 // practice; please don't create/use classes as unsafe as these examples.
 
-class ExampleUnsafeRenderable implements XHPUnsafeRenderable {
+class ExampleUnsafeRenderable implements Facebook\XHP\UnsafeRenderable {
   public function __construct(public string $htmlString) {
   }
 
@@ -23,10 +24,10 @@ class ExampleUnsafeRenderable implements XHPUnsafeRenderable {
 
 class ExampleVeryUnsafeRenderable
   extends ExampleUnsafeRenderable
-  implements XHPUnsafeRenderable, XHPAlwaysValidChild {
+  implements Facebook\XHP\UnsafeRenderable, Facebook\XHP\AlwaysValidChild {
 }
 
-class ExampleUnsafeAttribute extends XHPUnsafeAttributeValue {
+class ExampleUnsafeAttribute extends Facebook\XHP\UnsafeAttributeValue {
   public function __construct(public string $htmlString) {
   }
 
@@ -49,7 +50,7 @@ class UnsafeInterfacesTest extends Facebook\HackTest\HackTest {
       $x = new ExampleUnsafeRenderable('foo');
       $xhp = <html>{$x}<body /></html>;
       await $xhp->toStringAsync(); // validate, throw exception
-    })->toThrow(XHPInvalidChildrenException::class);
+    })->toThrow(Facebook\XHP\InvalidChildrenException::class);
   }
 
   public async function testAlwaysValidChild(): Awaitable<void> {

--- a/tests/XHPAttributeClobbering_DEPRECATEDTest.hack
+++ b/tests/XHPAttributeClobbering_DEPRECATEDTest.hack
@@ -7,9 +7,10 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use function Facebook\FBExpect\expect;
 
-xhp class test:no_xhphelpers extends :x:element {
+xhp class test:no_xhphelpers extends x\element {
   use XHPHTMLHelpers;
   attribute :xhp:html_element;
 
@@ -18,7 +19,7 @@ xhp class test:no_xhphelpers extends :x:element {
   }
 }
 
-xhp class test:xhphelpers extends :x:element {
+xhp class test:xhphelpers extends x\element {
   use XHPAttributeClobbering_DEPRECATED;
   attribute :xhp:html_element;
 
@@ -27,7 +28,7 @@ xhp class test:xhphelpers extends :x:element {
   }
 }
 
-xhp class test:async:no_xhphelpers extends :x:element {
+xhp class test:async:no_xhphelpers extends x\element {
   use XHPHTMLHelpers;
   attribute :xhp:html_element;
 
@@ -36,7 +37,7 @@ xhp class test:async:no_xhphelpers extends :x:element {
   }
 }
 
-xhp class test:async:xhphelpers extends :x:element {
+xhp class test:async:xhphelpers extends x\element {
   use XHPAttributeClobbering_DEPRECATED;
   attribute :xhp:html_element;
 
@@ -45,7 +46,7 @@ xhp class test:async:xhphelpers extends :x:element {
   }
 }
 
-xhp class test:with_class_on_root extends :x:element {
+xhp class test:with_class_on_root extends x\element {
   use XHPAttributeClobbering_DEPRECATED;
   attribute :xhp:html_element;
 

--- a/tests/XHPContextsTest.hack
+++ b/tests/XHPContextsTest.hack
@@ -7,9 +7,10 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
 use function Facebook\FBExpect\expect;
 
-xhp class test:contexts extends :x:element {
+xhp class test:contexts extends x\element {
   protected async function renderAsync(): Awaitable<XHPRoot> {
     return
       <div>

--- a/tests/XHPNamespaceTest.hack
+++ b/tests/XHPNamespaceTest.hack
@@ -7,10 +7,12 @@
  *
  */
 
+use namespace Facebook\XHP\Elements\Core as x;
+
 namespace MyTestNS {
 
   /** Intentionally conflicting name */
-  xhp class div extends :x:element {
+  xhp class div extends x\element {
     protected async function renderAsync(): Awaitable<\XHPRoot> {
       return
         <:div>
@@ -25,7 +27,7 @@ namespace MyTestNS {
   xhp class divsubclass2 extends :MyTestNS:div {
   }
 
-  xhp class useswithinnamespace extends :x:element {
+  xhp class useswithinnamespace extends x\element {
     protected async function renderAsync(): Awaitable<\XHPRoot> {
       return
         <:dl>
@@ -37,8 +39,8 @@ namespace MyTestNS {
           <:dd><divsubclass>content</divsubclass></:dd>
           <:dt>divsubclass2</:dt>
           <:dd><divsubclass2>content</divsubclass2></:dd>
-          <:dt>:x:frag</:dt>
-          <:dd><:x:frag>foo</:x:frag></:dd>
+          <:dt>x\frag</:dt>
+          <:dd><x:frag>foo</x:frag></:dd>
         </:dl>;
     }
   }
@@ -90,7 +92,7 @@ namespace {
             <dd>
               <div> -MyTestNS\divsubclass2-content-/MyTestNS\divsubclass2- </div>
             </dd>
-            <dt>:x:frag</dt>
+            <dt>x\frag</dt>
             <dd>foo</dd>
           </dl>
         )->toStringAsync(),


### PR DESCRIPTION
- core nodes to Facebook\XHP\Elements\Core
  - includes non-element nodes like :primitive, but feels like making
    this distinction would be worse for usability - e.g. Nodes\HTML
    wouldn't feel as right. Happy to change if there's strong feeligns
- everything else to Facebook\XHP
  - this includes exceptions and other non-node classes/interfaces

fixes #221

Doesn't entirely fix #221: there's `<x:conditional_comment>` but that's
really HTML-specific, so going to address as part of #219