### PR TITLE
<link> can be placed in the <body> in phrase and flow contexts

### DIFF
--- a/src/html/tags/l/Link.hack
+++ b/src/html/tags/l/Link.hack
@@ -19,6 +19,6 @@ xhp class link extends singleton {
     string rel @required,
     string sizes,
     string type;
-  category %metadata;
+  category %metadata, %phrase, %flow;
   protected string $tagName = 'link';
 }


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
![spec](https://user-images.githubusercontent.com/31805625/83446449-fa2ed900-a44e-11ea-821a-50126f529060.png)

Some of our older non XHP code loads css style sheets on the last line of the body.
This currently throws an `\XHPInvalidChildrenException` upon render with children validation enabled.