### PR TITLE
Make check_xhp_attribute not emit errors

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -12,5 +12,6 @@ disallow_array_literal = true
 disable_xhp_element_mangling=true
 enable_xhp_class_modifier=true
 disable_xhp_children_declarations=true
+check_xhp_attribute = true
 allowed_decl_fixme_codes=2049,2053,4045
-allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4108,4110,4128,4135,4188,4240,4281,4323,4343
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4108,4110,4128,4135,4188,4240,4281,4314,4323,4343

--- a/tests/AttributesTest.hack
+++ b/tests/AttributesTest.hack
@@ -113,6 +113,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
 
   public async function testOmittingRequiredAttributes(): Awaitable<void> {
     expect(() ==> {
+      /*HH_FIXME[4314] Attribute :mystring is not provided*/
       $x = <test:required_attributes />;
       expect($x->:mystring)->toBeNull();
     })->toThrow(Facebook\XHP\AttributeRequiredException::class);

--- a/tests/TestChildFlushing.hack
+++ b/tests/TestChildFlushing.hack
@@ -55,6 +55,7 @@ class XHPChildFlushTest extends Facebook\HackTest\HackTest {
     x\node $root,
     string $expected,
   ): Awaitable<void> {
+    /*HH_FIXME[4314] Attribute :root is not provided*/
     $elem = <test:verbatim_root />;
     $elem->setContext('root', $root);
     expect(await $elem->toStringAsync())->toEqual($expected);
@@ -65,6 +66,7 @@ class XHPChildFlushTest extends Facebook\HackTest\HackTest {
     x\node $root,
     string $expected,
   ): Awaitable<void> {
+    /*HH_FIXME[4314] Attribute :root is not provided*/
     $elem = <test:verbatim_root:async />;
     $elem->setContext('root', $root);
     expect(await $elem->toStringAsync())->toEqual($expected);


### PR DESCRIPTION
#258 electric boogaloo

Github decided to close the PR when I reset the world, since there were no pending commits.
I can't reopen that PR for some reason, even when there are pending commits.