### PR TITLE
Fix stringify() -> stringifyAsync()

### DIFF
--- a/src/html/singleton.hack
+++ b/src/html/singleton.hack
@@ -22,8 +22,8 @@ abstract xhp class singleton extends element {
     return XHPChild\empty();
   }
 
-
-  protected function stringify(): string {
+  <<__Override>>
+  protected async function stringifyAsync(): Awaitable<string> {
     return $this->renderBaseAttrs().'>';
   }
 }

--- a/src/html/unescaped_pcdata_element.hack
+++ b/src/html/unescaped_pcdata_element.hack
@@ -28,7 +28,8 @@ abstract xhp class unescaped_pcdata_element
   extends pcdata_element
   implements \Facebook\XHP\UnsafeRenderable {
 
-  protected function stringify(): string {
+  <<__Override>>
+  protected async function stringifyAsync(): Awaitable<string> {
     $buf = $this->renderBaseAttrs().'>';
     foreach ($this->getChildren() as $child) {
       if (!($child is string)) {
@@ -41,6 +42,6 @@ abstract xhp class unescaped_pcdata_element
   }
 
   final public async function toHTMLStringAsync(): Awaitable<string> {
-    return $this->stringify();
+    return await $this->stringifyAsync();
   }
 }

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -8,8 +8,9 @@
  */
 
 use namespace Facebook\XHP\Core as x;
-use type Facebook\XHP\HTML\div;
+use type Facebook\XHP\HTML\{br, div, img, singleton};
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\DataProvider;
 use namespace HH\Lib\C;
 
 xhp class test:renders_primitive extends x\element {
@@ -62,5 +63,26 @@ class BasicsTest extends Facebook\HackTest\HackTest {
   public async function testRendersPrimitive(): Awaitable<void> {
     $xhp = <test:renders_primitive />;
     expect(await $xhp->toStringAsync())->toEqual('<div>123</div>');
+  }
+
+  public function provideSingletonElements(): vec<(singleton, string)> {
+    return vec[
+      // This syntax creates the same object behind the scenes,
+      // but I put in an extra test, just in case.
+      tuple(<br></br>, '<br>'),
+      tuple(<br />, '<br>'),
+      tuple(
+        <img src="https://example.com/image.jpg" />,
+        '<img src="https://example.com/image.jpg">',
+      ),
+    ];
+  }
+
+  <<DataProvider('provideSingletonElements')>>
+  public async function testRenderedSingletonsShouldBeVoidElements(
+    singleton $void_element,
+    string $expect,
+  ): Awaitable<void> {
+    expect(await $void_element->toStringAsync())->toEqual($expect);
   }
 }

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -8,7 +8,7 @@
  */
 
 use namespace Facebook\XHP\Core as x;
-use type Facebook\XHP\HTML\{br, div, img, singleton};
+use type Facebook\XHP\HTML\{br, div, head, img, singleton, style};
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace HH\Lib\C;
@@ -84,5 +84,13 @@ class BasicsTest extends Facebook\HackTest\HackTest {
     string $expect,
   ): Awaitable<void> {
     expect(await $void_element->toStringAsync())->toEqual($expect);
+  }
+
+  public async function testUnescapedPCDataElementDoesNotEscapeItsChild(
+  ): Awaitable<void> {
+    $dangerous_chars = '"\'<>&';
+    expect(
+      await (<head><style>{$dangerous_chars}</style></head>)->toStringAsync(),
+    )->toEqual('<head><style>'.$dangerous_chars.'</style></head>');
   }
 }


### PR DESCRIPTION
The old name for this method was `->stringify()`.
These stragglers did not have an `__Override` on `->stringify()`, so the typechecker could not warn us about this.

Fixes:
`<br/>` now renders as `<br>` again (not `<br></br>`).
`<style>&</style>` now renders as `<style>&</style>` again, (not `<style>&amp;</style>`).