### PR TITLE
[ Incorrect | Being replaced ] Add svg support

### DIFF
--- a/IMPORTANT_CLA_INFORMATION__REMOVE_THIS_FILE.md
+++ b/IMPORTANT_CLA_INFORMATION__REMOVE_THIS_FILE.md
@@ -1,0 +1,132 @@
+# IMPORTANT CLA INFORMATION
+
+## Submitted on behalf of third-party: Scott Sandler
+
+According to the Facebook CLA:
+```
+Should You wish to submit work that is not Your original creation, You may submit it to Facebook separately from any Contribution, identifying the complete details of its source and of any license or other restriction ... and conspicuously marking the work as 'Submitted on behalf of third-party: [named here].
+```
+
+## Origins of the submitted work
+
+The Contribution on this branch is the of work from [Scott Sandler](https://github.com/ssandler).
+The original was submitted to me via a Slack message.
+This was prompted by [this PR comment](https://github.com/hhvm/xhp-lib/pull/260#issuecomment-645657478).
+This work was given to me with the express purpose of integrating this into the `hhvm/xhp-lib` sources.
+The next commit will introduce an XHP-4 compatible version of this work into the `/src/html/tags/*` directory.
+The differences between `## The submitted work` and the code in `/src/html/tags/*` are my own.
+
+## The submitted work
+
+```HACK
+<?hh // strict
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle
+*/
+final class :circle extends :svg {
+	attribute
+		string cx,
+		string cy,
+		string r;
+	protected string $tagName = 'circle';
+}
+<?hh // strict
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs
+*/
+final class :defs extends :svg {
+	protected string $tagName = 'defs';
+}
+<?hh // strict
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
+*/
+final class :g extends :svg {
+	protected string $tagName = 'g';
+}
+<?hh // strict
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mask
+*/
+final class :mask extends :svg {
+	protected string $tagName = 'mask';
+}
+<?hh // strict
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path
+*/
+final class :path extends :svg {
+	attribute
+		string d,
+		int pathLength;
+	protected string $tagName = 'path';
+}
+<?hh // strict
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/polygon
+*/
+final class :polygon extends :svg {
+	attribute
+		string points,
+		num pathLength;
+	protected string $tagName = 'polygon';
+}
+<?hh // strict
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
+*/
+/* HHAST_FIXME[FinalOrAbstractClass] */ class :svg extends :xhp:html-element {
+	attribute
+		string width,
+		string height,
+		string viewBox,
+		string version,
+		string xmlns,
+		string xmlns:xlink,
+		num x,
+		num y,
+		string preserveAspectRatio,
+		string clip-path,
+		string clip-rule,
+		string color,
+		string color-interpolation,
+		string color-rendering,
+		string cursor,
+		string display,
+		string fill,
+		string fill-opacity,
+		string fill-rule,
+		string filter,
+		string mask,
+		string opacity,
+		string pointer-events,
+		string shape-rendering,
+		string stroke,
+		string stroke-dasharray,
+		string stroke-dashoffset,
+		string stroLICENSEke-linecap,
+		string stroke-linejoin,
+		string stroke-miterlimit,
+		string stroke-opacity,
+		string stroke-width,
+		string transform,
+		string vector-effect,
+		string visibility;
+	category %phrase;
+	children (pcdata | %flow | %phrase)*;
+	protected string $tagName = 'svg';
+}
+<?hh // strict
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+*/
+final class :use extends :svg {
+	attribute Stringish xlink:href;
+	protected string $tagName = 'use';
+}
+```
+
+### Footnote
+
+As far as my understanding of the Facebook CLA goes, I have now done what is required in order to submit this work.
+If this is not the case, please inform me, so I can correct this.

--- a/src/html/tags/c/Circle.hack
+++ b/src/html/tags/c/Circle.hack
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\HTML;
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle
+ */
+final xhp class circle extends svg {
+  attribute
+    string cx,
+    string cy,
+    string r;
+  protected string $tagName = 'circle';
+}

--- a/src/html/tags/g/G.hack
+++ b/src/html/tags/g/G.hack
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\HTML;
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
+ */
+final xhp class g extends svg {
+  protected string $tagName = 'g';
+}

--- a/src/html/tags/m/Mask.hack
+++ b/src/html/tags/m/Mask.hack
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\HTML;
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mask
+ */
+final xhp class mask extends svg {
+  protected string $tagName = 'mask';
+}

--- a/src/html/tags/p/Path.hack
+++ b/src/html/tags/p/Path.hack
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\HTML;
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path
+ */
+final xhp class path extends svg {
+  attribute
+    string d,
+    int pathLength;
+  protected string $tagName = 'path';
+}

--- a/src/html/tags/p/Polygon.hack
+++ b/src/html/tags/p/Polygon.hack
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\HTML;
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/SVG/Element/polygon
+ */
+final xhp class polygon extends svg {
+  attribute
+    string points,
+    num pathLength;
+  protected string $tagName = 'polygon';
+}

--- a/src/html/tags/s/Svg.hack
+++ b/src/html/tags/s/Svg.hack
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\HTML;
+
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
+ */
+/* HHAST_FIXME[FinalOrAbstractClass] */
+xhp class svg extends element {
+  attribute
+    string width,
+    string height,
+    string viewBox,
+    string version,
+    string xmlns,
+    string xmlns:xlink,
+    num x,
+    num y,
+    string preserveAspectRatio,
+    string clip-path,
+    string clip-rule,
+    string color,
+    string color-interpolation,
+    string color-rendering,
+    string cursor,
+    string display,
+    string fill,
+    string fill-opacity,
+    string fill-rule,
+    string filter,
+    string mask,
+    string opacity,
+    string pointer-events,
+    string shape-rendering,
+    string stroke,
+    string stroke-dasharray,
+    string stroke-dashoffset,
+    string stroke-linecap,
+    string stroke-linejoin,
+    string stroke-miterlimit,
+    string stroke-opacity,
+    string stroke-width,
+    string transform,
+    string vector-effect,
+    string visibility;
+  category %phrase;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\anyNumberOf(
+      XHPChild\anyOf(XHPChild\pcdata(), XHPChild\category('%phrase')),
+    );
+  }
+
+  protected string $tagName = 'svg';
+}

--- a/src/html/tags/u/Use.hack
+++ b/src/html/tags/u/Use.hack
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\XHP\HTML;
+
+/**
+* https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+*/
+final xhp class use extends svg {
+  attribute string xlink:href;
+  protected string $tagName = 'use';
+}

--- a/tests/SvgImageTest.hack
+++ b/tests/SvgImageTest.hack
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace Facebook\XHP\Core as x;
+use type Facebook\XHP\HTML\{svg, g, circle, animate};
+
+use function Facebook\FBExpect\expect;
+
+
+final class SvgImageTest extends Facebook\HackTest\HackTest {
+  /**
+   * Source: https://github.com/rendro/SVG-Spinner/blob/379a1169c4c24a35e1d000d061378c39eea997e6/images/spinning-loader.svg
+   * License: Do What The F*ck You Want To Public License
+   * https://choosealicense.com/licenses/wtfpl/
+   *
+   * This is the most permissive SVG image I could find.
+   * This license imposes zero limitations.
+   * We can therefore freely relicense it under the xhp-lib MIT license.
+   */
+  public async function testSvgRendering(): Awaitable<void> {
+    $svg =
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        version="1.1"
+        width="110px"
+        height="110px">
+        <g>
+          <circle cx="50" cy="0" r="5" transform="translate(5 5)" />
+          <circle cx="75" cy="6.6987298" r="5" transform="translate(5 5)" />
+          <circle cx="93.3012702" cy="25" r="5" transform="translate(5 5)" />
+          <circle cx="100" cy="50" r="5" transform="translate(5 5)" />
+          <circle cx="93.3012702" cy="75" r="5" transform="translate(5 5)" />
+          <circle cx="75" cy="93.3012702" r="5" transform="translate(5 5)" />
+          <circle cx="50" cy="100" r="5" transform="translate(5 5)" />
+          <circle cx="25" cy="93.3012702" r="5" transform="translate(5 5)" />
+          <circle cx="6.6987298" cy="75" r="5" transform="translate(5 5)" />
+          <circle cx="0" cy="50" r="5" transform="translate(5 5)" />
+          <circle cx="6.6987298" cy="25" r="5" transform="translate(5 5)" />
+          <circle cx="25" cy="6.6987298" r="5" transform="translate(5 5)" />
+        </g>
+      </svg>;
+    expect(await $svg->toStringAsync())->toNotBeEmpty();
+  }
+}


### PR DESCRIPTION
Submitted on behalf of third-party: Scott Sandler
Commit cc57260 contains [Scott Sandler's]() work under the `## The submitted work` heading in IMPORTANT_CLA_INFORMATION__REMOVE_THIS_FILE.md.
End of third-party work.

Commit 598a975 ports these changes to xhp-4.
Commit 9a99521 adds a test for rendering a subset of the new tags.

The svg namespace is not yet complete, but I did not want to submit a boatload of my work in the same PR that needs to have this big CLA disclaimer.
Again, I hope that I am doing this right.
If not, please tell me.