### PR TITLE
Replace categories with interfaces

### DIFF
--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -91,7 +91,7 @@ abstract xhp class node implements \XHPChild {
    * @param $child     single child or a Traversable of children
    */
   final public function appendChild(mixed $child): this {
-    invariant(!$this->__isRendered, "Can't appendChild after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     if ($child is Traversable<_>) {
       foreach ($child as $c) {
         $this->appendChild($c);
@@ -113,7 +113,7 @@ abstract xhp class node implements \XHPChild {
    * @param $children  single child or a Traversable of children
    */
   final public function replaceChildren(\XHPChild ...$children): this {
-    invariant(!$this->__isRendered, "Can't appendChild after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     // This function has been micro-optimized
     $new_children = vec[];
     foreach ($children as $xhp) {
@@ -339,7 +339,7 @@ abstract xhp class node implements \XHPChild {
    * @param $val       value
    */
   final public function setAttribute(string $attr, mixed $value): this {
-    invariant(!$this->__isRendered, "Can't setAttribute after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     $this->attributes[$attr] = $value;
     return $this;
   }
@@ -374,7 +374,7 @@ abstract xhp class node implements \XHPChild {
    * @param $attr      attribute to remove
    */
   final public function removeAttribute(string $attr): this {
-    invariant(!$this->__isRendered, "Can't removeAttribute after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     unset($this->attributes[$attr]);
     return $this;
   }
@@ -389,7 +389,7 @@ abstract xhp class node implements \XHPChild {
    * @param $val       value
    */
   final public function forceAttribute(string $attr, mixed $value): this {
-    invariant(!$this->__isRendered, "Can't forceAttribute after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     $this->attributes[$attr] = $value;
     return $this;
   }
@@ -429,7 +429,7 @@ abstract xhp class node implements \XHPChild {
    * @return           $this
    */
   final public function setContext(string $key, mixed $value): this {
-    invariant(!$this->__isRendered, "Can't setContext after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     $this->context[$key] = $value;
     return $this;
   }
@@ -447,7 +447,7 @@ abstract xhp class node implements \XHPChild {
   final public function addContextMap(
     KeyedContainer<string, mixed> $context,
   ): this {
-    invariant(!$this->__isRendered, "Can't setContext after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     $this->context = Dict\merge($this->context, $context);
     return $this;
   }

--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -169,6 +169,16 @@ abstract xhp class node implements \XHPChild {
     return $children;
   }
 
+  public function getChildrenOfType<<<__Enforceable>> reify T>(): vec<T> {
+    $children = vec[];
+    foreach ($this->children as $child) {
+      if ($child is T) {
+        $children[] = $child;
+      }
+    }
+    return $children;
+  }
+
 
   /**
    * Fetches the first direct child of the element, or the first child that
@@ -198,6 +208,32 @@ abstract xhp class node implements \XHPChild {
     return null;
   }
 
+  public function getFirstChildx(?string $selector = null): \XHPChild {
+    $child = $this->getFirstChild($selector);
+    if ($child is nonnull) {
+      return $child;
+    }
+    if ($selector === '' || $selector is null) {
+      invariant_violation('Cannot get first child, element has no children');
+    }
+    invariant_violation('No child matching selector "%s" found', $selector);
+  }
+
+  public function getFirstChildOfType<<<__Enforceable>> reify T>(): ?T {
+    foreach ($this->children as $child) {
+      if ($child is T) {
+        return $child;
+      }
+    }
+    return null;
+  }
+
+  public function getFirstChildOfTypex<<<__Enforceable>> reify T>(): T {
+    $child = $this->getFirstChildOfType<T>();
+    invariant($child is nonnull, 'No such child');
+    return $child;
+  }
+
   /**
    * Fetches the last direct child of the element, or the last child that
    * matches the tag or category if one is given
@@ -208,6 +244,34 @@ abstract xhp class node implements \XHPChild {
    */
   final public function getLastChild(?string $selector = null): ?\XHPChild {
     return $this->getChildren($selector) |> C\last($$);
+  }
+
+  public function getLastChildx(?string $selector = null): \XHPChild {
+    $child = $this->getLastChild($selector);
+    if ($child is nonnull) {
+      return $child;
+    }
+    if ($selector === '' || $selector is null) {
+      invariant_violation('Cannot get last child, element has no children');
+    }
+    invariant_violation('No child matching selector "%s" found', $selector);
+  }
+
+
+  public function getLastChildOfType<<<__Enforceable>> reify T>(): ?T {
+    for ($i = C\count($this->children) - 1; $i >= 0; --$i) {
+      $child = $this->children[$i];
+      if ($child is T) {
+        return $child;
+      }
+    }
+    return null;
+  }
+
+  public function getLastChildOfTypex<<<__Enforceable>> reify T>(): T {
+    $child = $this->getLastChildOfType<T>();
+    invariant($child is nonnull, 'No such child');
+    return $child;
   }
 
   /**

--- a/src/core/Primitive.hack
+++ b/src/core/Primitive.hack
@@ -22,8 +22,11 @@ abstract xhp class primitive extends node {
 
   <<__Override>>
   final public async function toStringAsync(): Awaitable<string> {
+    invariant(!$this->__isRendered, 'Attempted to render XHP element twice');
     $that = await $this->__flushSubtree();
-    return await $that->stringifyAsync();
+    $result = await $that->stringifyAsync();
+    $this->__isRendered = true;
+    return $result;
   }
 
   final private async function __flushElementChildren(): Awaitable<void> {

--- a/src/html/categories/Embedded.hack
+++ b/src/html/categories/Embedded.hack
@@ -7,6 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML\Cat;
+namespace Facebook\XHP\HTML\Category;
 
-interface InteractiveElement {}
+interface Embedded {}

--- a/src/html/categories/EmbeddedElement.hack
+++ b/src/html/categories/EmbeddedElement.hack
@@ -7,10 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML;
+namespace Facebook\XHP\HTML\Cat;
 
-final xhp class wbr
-  extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
-  protected string $tagName = 'wbr';
-}
+interface EmbeddedElement {}

--- a/src/html/categories/Flow.hack
+++ b/src/html/categories/Flow.hack
@@ -7,6 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML\Cat;
+namespace Facebook\XHP\HTML\Category;
 
-interface SectioningElement {}
+interface Flow {}

--- a/src/html/categories/FlowElement.hack
+++ b/src/html/categories/FlowElement.hack
@@ -7,10 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML;
+namespace Facebook\XHP\HTML\Cat;
 
-final xhp class wbr
-  extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
-  protected string $tagName = 'wbr';
-}
+interface FlowElement {}

--- a/src/html/categories/Heading.hack
+++ b/src/html/categories/Heading.hack
@@ -7,6 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML\Cat;
+namespace Facebook\XHP\HTML\Category;
 
-interface EmbeddedElement {}
+interface Heading {}

--- a/src/html/categories/HeadingElement.hack
+++ b/src/html/categories/HeadingElement.hack
@@ -7,10 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML;
+namespace Facebook\XHP\HTML\Cat;
 
-final xhp class wbr
-  extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
-  protected string $tagName = 'wbr';
-}
+interface HeadingElement {}

--- a/src/html/categories/Interactive.hack
+++ b/src/html/categories/Interactive.hack
@@ -7,6 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML\Cat;
+namespace Facebook\XHP\HTML\Category;
 
-interface PhraseElement {}
+interface Interactive {}

--- a/src/html/categories/InteractiveElement.hack
+++ b/src/html/categories/InteractiveElement.hack
@@ -7,10 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML;
+namespace Facebook\XHP\HTML\Cat;
 
-final xhp class wbr
-  extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
-  protected string $tagName = 'wbr';
-}
+interface InteractiveElement {}

--- a/src/html/categories/Metadata.hack
+++ b/src/html/categories/Metadata.hack
@@ -7,6 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML\Cat;
+namespace Facebook\XHP\HTML\Category;
 
-interface MetadataElement {}
+interface Metadata {}

--- a/src/html/categories/MetadataElement.hack
+++ b/src/html/categories/MetadataElement.hack
@@ -7,10 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML;
+namespace Facebook\XHP\HTML\Cat;
 
-final xhp class wbr
-  extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
-  protected string $tagName = 'wbr';
-}
+interface MetadataElement {}

--- a/src/html/categories/Phrase.hack
+++ b/src/html/categories/Phrase.hack
@@ -7,6 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML\Cat;
+namespace Facebook\XHP\HTML\Category;
 
-interface FlowElement {}
+interface Phrase {}

--- a/src/html/categories/PhraseElement.hack
+++ b/src/html/categories/PhraseElement.hack
@@ -7,10 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML;
+namespace Facebook\XHP\HTML\Cat;
 
-final xhp class wbr
-  extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
-  protected string $tagName = 'wbr';
-}
+interface PhraseElement {}

--- a/src/html/categories/Sectioning.hack
+++ b/src/html/categories/Sectioning.hack
@@ -7,6 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML\Cat;
+namespace Facebook\XHP\HTML\Category;
 
-interface HeadingElement {}
+interface Sectioning {}

--- a/src/html/categories/SectioningElement.hack
+++ b/src/html/categories/SectioningElement.hack
@@ -7,10 +7,6 @@
  *
  */
 
-namespace Facebook\XHP\HTML;
+namespace Facebook\XHP\HTML\Cat;
 
-final xhp class wbr
-  extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
-  protected string $tagName = 'wbr';
-}
+interface SectioningElement {}

--- a/src/html/tags/a/A.hack
+++ b/src/html/tags/a/A.hack
@@ -42,7 +42,7 @@ final xhp class a
   // Should not contain %interactive
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/a/A.hack
+++ b/src/html/tags/a/A.hack
@@ -11,7 +11,9 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class a extends element {
+final xhp class a
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
   use XHPChild\Validation;
 
   attribute
@@ -36,7 +38,7 @@ final xhp class a extends element {
     string type,
     // Legacy
     string name;
-  category %flow, %phrase, %interactive;
+
   // Should not contain %interactive
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/a/A.hack
+++ b/src/html/tags/a/A.hack
@@ -13,7 +13,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class a
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive {
   use XHPChild\Validation;
 
   attribute
@@ -42,7 +45,10 @@ final xhp class a
   // Should not contain %interactive
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/a/Abbr.hack
+++ b/src/html/tags/a/Abbr.hack
@@ -18,7 +18,7 @@ final xhp class abbr
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/a/Abbr.hack
+++ b/src/html/tags/a/Abbr.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class abbr
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/a/Abbr.hack
+++ b/src/html/tags/a/Abbr.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class abbr extends element {
+final xhp class abbr
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/a/Address.hack
+++ b/src/html/tags/a/Address.hack
@@ -11,13 +11,16 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class address extends element implements Cat\FlowElement {
+final xhp class address extends element implements Category\Flow {
   use XHPChild\Validation;
 
   // May not contain %heading, %sectioning, :header, :footer, or :address
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/a/Address.hack
+++ b/src/html/tags/a/Address.hack
@@ -11,9 +11,9 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class address extends element {
+final xhp class address extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
+
   // May not contain %heading, %sectioning, :header, :footer, or :address
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/a/Address.hack
+++ b/src/html/tags/a/Address.hack
@@ -17,7 +17,7 @@ final xhp class address extends element implements Cat\FlowElement {
   // May not contain %heading, %sectioning, :header, :footer, or :address
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/a/Area.hack
+++ b/src/html/tags/a/Area.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 final xhp class area
   extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   attribute
     string alt,
     string coords,

--- a/src/html/tags/a/Area.hack
+++ b/src/html/tags/a/Area.hack
@@ -9,7 +9,9 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class area extends singleton {
+final xhp class area
+  extends singleton
+  implements Cat\PhraseElement, Cat\FlowElement {
   attribute
     string alt,
     string coords,
@@ -41,6 +43,6 @@ final xhp class area extends singleton {
     } shape,
     string target,
     string type;
-  category %flow, %phrase;
+
   protected string $tagName = 'area';
 }

--- a/src/html/tags/a/Article.hack
+++ b/src/html/tags/a/Article.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class article extends element {
+final xhp class article
+  extends element
+  implements Cat\FlowElement, Cat\SectioningElement {
   use XHPChild\Validation;
-  category %flow, %sectioning;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/a/Article.hack
+++ b/src/html/tags/a/Article.hack
@@ -18,7 +18,7 @@ final xhp class article
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/a/Article.hack
+++ b/src/html/tags/a/Article.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class article
   extends element
-  implements Cat\FlowElement, Cat\SectioningElement {
+  implements Category\Flow, Category\Sectioning {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/a/Aside.hack
+++ b/src/html/tags/a/Aside.hack
@@ -18,7 +18,7 @@ final xhp class aside
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/a/Aside.hack
+++ b/src/html/tags/a/Aside.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class aside extends element {
+final xhp class aside
+  extends element
+  implements Cat\FlowElement, Cat\SectioningElement {
   use XHPChild\Validation;
-  category %flow, %sectioning;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/a/Aside.hack
+++ b/src/html/tags/a/Aside.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class aside
   extends element
-  implements Cat\FlowElement, Cat\SectioningElement {
+  implements Category\Flow, Category\Sectioning {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/a/Audio.hack
+++ b/src/html/tags/a/Audio.hack
@@ -14,10 +14,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 final xhp class audio
   extends element
   implements
-    Cat\PhraseElement,
-    Cat\FlowElement,
-    Cat\InteractiveElement,
-    Cat\EmbeddedElement {
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive,
+    Category\Embedded {
   use XHPChild\Validation;
   attribute
     bool autoplay,
@@ -34,7 +34,10 @@ final xhp class audio
       XHPChild\any_number_of(XHPChild\of_type<source>()),
       XHPChild\any_number_of(XHPChild\of_type<track>()),
       XHPChild\any_number_of(
-        XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+        XHPChild\any_of(
+          XHPChild\pcdata(),
+          XHPChild\of_type<Category\Flow>(),
+        ),
       ),
     );
   }

--- a/src/html/tags/a/Audio.hack
+++ b/src/html/tags/a/Audio.hack
@@ -11,7 +11,13 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class audio extends element {
+final xhp class audio
+  extends element
+  implements
+    Cat\PhraseElement,
+    Cat\FlowElement,
+    Cat\InteractiveElement,
+    Cat\EmbeddedElement {
   use XHPChild\Validation;
   attribute
     bool autoplay,
@@ -22,7 +28,6 @@ final xhp class audio extends element {
     bool muted,
     enum {'none', 'metadata', 'auto'} preload,
     string src;
-  category %flow, %phrase, %embedded, %interactive;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(

--- a/src/html/tags/a/Audio.hack
+++ b/src/html/tags/a/Audio.hack
@@ -34,7 +34,7 @@ final xhp class audio
       XHPChild\any_number_of(XHPChild\of_type<source>()),
       XHPChild\any_number_of(XHPChild\of_type<track>()),
       XHPChild\any_number_of(
-        XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+        XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
       ),
     );
   }

--- a/src/html/tags/b/B.hack
+++ b/src/html/tags/b/B.hack
@@ -18,7 +18,7 @@ final xhp class b
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/b/B.hack
+++ b/src/html/tags/b/B.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class b extends element {
+final xhp class b
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/b/B.hack
+++ b/src/html/tags/b/B.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class b
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/b/Base.hack
+++ b/src/html/tags/b/Base.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class base extends singleton implements Cat\MetadataElement {
+final xhp class base extends singleton implements Category\Metadata {
   attribute
     string href,
     string target;

--- a/src/html/tags/b/Base.hack
+++ b/src/html/tags/b/Base.hack
@@ -9,10 +9,10 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class base extends singleton {
+final xhp class base extends singleton implements Cat\MetadataElement {
   attribute
     string href,
     string target;
-  category %metadata;
+
   protected string $tagName = 'base';
 }

--- a/src/html/tags/b/Bdi.hack
+++ b/src/html/tags/b/Bdi.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class bdi extends element {
+final xhp class bdi
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/b/Bdi.hack
+++ b/src/html/tags/b/Bdi.hack
@@ -18,7 +18,7 @@ final xhp class bdi
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/b/Bdi.hack
+++ b/src/html/tags/b/Bdi.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class bdi
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/b/Bdo.hack
+++ b/src/html/tags/b/Bdo.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class bdo
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/b/Bdo.hack
+++ b/src/html/tags/b/Bdo.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class bdo extends element {
+final xhp class bdo
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/b/Bdo.hack
+++ b/src/html/tags/b/Bdo.hack
@@ -18,7 +18,7 @@ final xhp class bdo
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/b/Blockquote.hack
+++ b/src/html/tags/b/Blockquote.hack
@@ -13,13 +13,16 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class blockquote
   extends element
-  implements Cat\FlowElement, Cat\SectioningElement {
+  implements Category\Flow, Category\Sectioning {
   use XHPChild\Validation;
   attribute string cite;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/b/Blockquote.hack
+++ b/src/html/tags/b/Blockquote.hack
@@ -11,10 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class blockquote extends element {
+final xhp class blockquote
+  extends element
+  implements Cat\FlowElement, Cat\SectioningElement {
   use XHPChild\Validation;
   attribute string cite;
-  category %flow, %sectioning;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/b/Blockquote.hack
+++ b/src/html/tags/b/Blockquote.hack
@@ -19,7 +19,7 @@ final xhp class blockquote
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/b/Body.hack
+++ b/src/html/tags/b/Body.hack
@@ -32,7 +32,10 @@ final xhp class body extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/b/Body.hack
+++ b/src/html/tags/b/Body.hack
@@ -32,7 +32,7 @@ final xhp class body extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/b/Br.hack
+++ b/src/html/tags/b/Br.hack
@@ -9,7 +9,9 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class br extends singleton {
-  category %flow, %phrase;
+final xhp class br
+  extends singleton
+  implements Cat\PhraseElement, Cat\FlowElement {
+
   protected string $tagName = 'br';
 }

--- a/src/html/tags/b/Br.hack
+++ b/src/html/tags/b/Br.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 final xhp class br
   extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
 
   protected string $tagName = 'br';
 }

--- a/src/html/tags/b/Button.hack
+++ b/src/html/tags/b/Button.hack
@@ -31,7 +31,7 @@ final xhp class button
   // Should not contain interactive
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/b/Button.hack
+++ b/src/html/tags/b/Button.hack
@@ -13,7 +13,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class button
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive {
   use XHPChild\Validation;
   attribute
     bool disabled,
@@ -31,7 +34,10 @@ final xhp class button
   // Should not contain interactive
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/b/Button.hack
+++ b/src/html/tags/b/Button.hack
@@ -11,7 +11,9 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class button extends element {
+final xhp class button
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
   use XHPChild\Validation;
   attribute
     bool disabled,
@@ -25,7 +27,7 @@ final xhp class button extends element {
     string name,
     enum {'submit', 'button', 'reset'} type,
     string value;
-  category %flow, %phrase, %interactive;
+
   // Should not contain interactive
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/c/Canvas.hack
+++ b/src/html/tags/c/Canvas.hack
@@ -22,7 +22,7 @@ final xhp class canvas
   // Should not contain :table
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/c/Canvas.hack
+++ b/src/html/tags/c/Canvas.hack
@@ -13,7 +13,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class canvas
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\EmbeddedElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Embedded {
   use XHPChild\Validation;
   attribute
     int height,
@@ -22,7 +25,10 @@ final xhp class canvas
   // Should not contain :table
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/c/Canvas.hack
+++ b/src/html/tags/c/Canvas.hack
@@ -11,12 +11,14 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class canvas extends element {
+final xhp class canvas
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\EmbeddedElement {
   use XHPChild\Validation;
   attribute
     int height,
     int width;
-  category %flow, %phrase, %embedded;
+
   // Should not contain :table
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/c/Caption.hack
+++ b/src/html/tags/c/Caption.hack
@@ -16,7 +16,10 @@ final xhp class caption extends element {
   // Should not contain :table
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/c/Caption.hack
+++ b/src/html/tags/c/Caption.hack
@@ -16,7 +16,7 @@ final xhp class caption extends element {
   // Should not contain :table
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/c/Cite.hack
+++ b/src/html/tags/c/Cite.hack
@@ -18,7 +18,7 @@ final xhp class cite
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/c/Cite.hack
+++ b/src/html/tags/c/Cite.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class cite
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/c/Cite.hack
+++ b/src/html/tags/c/Cite.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class cite extends element {
+final xhp class cite
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/c/Code.hack
+++ b/src/html/tags/c/Code.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class code extends element {
+final xhp class code
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/c/Code.hack
+++ b/src/html/tags/c/Code.hack
@@ -18,7 +18,7 @@ final xhp class code
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/c/Code.hack
+++ b/src/html/tags/c/Code.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class code
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/d/Data.hack
+++ b/src/html/tags/d/Data.hack
@@ -11,10 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class data extends element {
+final xhp class data
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute string value @required;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(XHPChild\category('%phrase'));

--- a/src/html/tags/d/Data.hack
+++ b/src/html/tags/d/Data.hack
@@ -18,7 +18,7 @@ final xhp class data
   attribute string value @required;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\any_number_of(XHPChild\category('%phrase'));
+    return XHPChild\any_number_of(XHPChild\of_type<Cat\PhraseElement>());
   }
 
   protected string $tagName = 'data';

--- a/src/html/tags/d/Data.hack
+++ b/src/html/tags/d/Data.hack
@@ -13,12 +13,12 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class data
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute string value @required;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\any_number_of(XHPChild\of_type<Cat\PhraseElement>());
+    return XHPChild\any_number_of(XHPChild\of_type<Category\Phrase>());
   }
 
   protected string $tagName = 'data';

--- a/src/html/tags/d/Datalist.hack
+++ b/src/html/tags/d/Datalist.hack
@@ -13,12 +13,12 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class datalist
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_of(
-      XHPChild\at_least_one_of(XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\at_least_one_of(XHPChild\of_type<Category\Phrase>()),
       XHPChild\any_number_of(XHPChild\of_type<option>()),
     );
   }

--- a/src/html/tags/d/Datalist.hack
+++ b/src/html/tags/d/Datalist.hack
@@ -18,7 +18,7 @@ final xhp class datalist
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_of(
-      XHPChild\at_least_one_of(XHPChild\category('%phrase')),
+      XHPChild\at_least_one_of(XHPChild\of_type<Cat\PhraseElement>()),
       XHPChild\any_number_of(XHPChild\of_type<option>()),
     );
   }

--- a/src/html/tags/d/Datalist.hack
+++ b/src/html/tags/d/Datalist.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class datalist extends element {
+final xhp class datalist
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_of(

--- a/src/html/tags/d/Dd.hack
+++ b/src/html/tags/d/Dd.hack
@@ -16,7 +16,10 @@ final xhp class dd extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/d/Dd.hack
+++ b/src/html/tags/d/Dd.hack
@@ -16,7 +16,7 @@ final xhp class dd extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/d/Del.hack
+++ b/src/html/tags/d/Del.hack
@@ -13,7 +13,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class del
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute
     string cite,
@@ -22,7 +22,10 @@ final xhp class del
   // transparent
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/d/Del.hack
+++ b/src/html/tags/d/Del.hack
@@ -11,12 +11,14 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class del extends element {
+final xhp class del
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     string cite,
     string datetime;
-  category %flow, %phrase;
+
   // transparent
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/d/Del.hack
+++ b/src/html/tags/d/Del.hack
@@ -22,7 +22,7 @@ final xhp class del
   // transparent
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/d/Details.hack
+++ b/src/html/tags/d/Details.hack
@@ -13,14 +13,17 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class details
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive {
   use XHPChild\Validation;
   attribute bool open;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(
       XHPChild\of_type<summary>(),
-      XHPChild\at_least_one_of(XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\at_least_one_of(XHPChild\of_type<Category\Flow>()),
     );
   }
 

--- a/src/html/tags/d/Details.hack
+++ b/src/html/tags/d/Details.hack
@@ -11,10 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class details extends element {
+final xhp class details
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
   use XHPChild\Validation;
   attribute bool open;
-  category %flow, %phrase, %interactive;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(

--- a/src/html/tags/d/Details.hack
+++ b/src/html/tags/d/Details.hack
@@ -20,7 +20,7 @@ final xhp class details
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(
       XHPChild\of_type<summary>(),
-      XHPChild\at_least_one_of(XHPChild\category('%flow')),
+      XHPChild\at_least_one_of(XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/d/Dfn.hack
+++ b/src/html/tags/d/Dfn.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class dfn extends element {
+final xhp class dfn
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/d/Dfn.hack
+++ b/src/html/tags/d/Dfn.hack
@@ -18,7 +18,7 @@ final xhp class dfn
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/d/Dfn.hack
+++ b/src/html/tags/d/Dfn.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class dfn
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/d/Dialog.hack
+++ b/src/html/tags/d/Dialog.hack
@@ -11,10 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class dialog extends element {
+final xhp class dialog
+  extends element
+  implements Cat\FlowElement, Cat\SectioningElement {
   use XHPChild\Validation;
   attribute bool open;
-  category %flow, %sectioning;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\category('%flow');

--- a/src/html/tags/d/Dialog.hack
+++ b/src/html/tags/d/Dialog.hack
@@ -18,7 +18,7 @@ final xhp class dialog
   attribute bool open;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\category('%flow');
+    return XHPChild\of_type<Cat\FlowElement>();
   }
 
   protected string $tagName = 'dialog';

--- a/src/html/tags/d/Dialog.hack
+++ b/src/html/tags/d/Dialog.hack
@@ -13,12 +13,12 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class dialog
   extends element
-  implements Cat\FlowElement, Cat\SectioningElement {
+  implements Category\Flow, Category\Sectioning {
   use XHPChild\Validation;
   attribute bool open;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\of_type<Cat\FlowElement>();
+    return XHPChild\of_type<Category\Flow>();
   }
 
   protected string $tagName = 'dialog';

--- a/src/html/tags/d/Div.hack
+++ b/src/html/tags/d/Div.hack
@@ -16,7 +16,7 @@ final xhp class div extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/d/Div.hack
+++ b/src/html/tags/d/Div.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class div extends element implements Cat\FlowElement {
+final xhp class div extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/d/Div.hack
+++ b/src/html/tags/d/Div.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class div extends element {
+final xhp class div extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/d/Dl.hack
+++ b/src/html/tags/d/Dl.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class dl extends element implements Cat\FlowElement {
+final xhp class dl extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {

--- a/src/html/tags/d/Dl.hack
+++ b/src/html/tags/d/Dl.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class dl extends element {
+final xhp class dl extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(XHPChild\sequence(

--- a/src/html/tags/d/Dt.hack
+++ b/src/html/tags/d/Dt.hack
@@ -16,7 +16,7 @@ final xhp class dt extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/d/Dt.hack
+++ b/src/html/tags/d/Dt.hack
@@ -16,7 +16,10 @@ final xhp class dt extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/e/Em.hack
+++ b/src/html/tags/e/Em.hack
@@ -18,7 +18,7 @@ final xhp class em
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/e/Em.hack
+++ b/src/html/tags/e/Em.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class em extends element {
+final xhp class em
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/e/Em.hack
+++ b/src/html/tags/e/Em.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class em
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/e/Embed.hack
+++ b/src/html/tags/e/Embed.hack
@@ -11,7 +11,13 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class embed extends element {
+final xhp class embed
+  extends element
+  implements
+    Cat\PhraseElement,
+    Cat\FlowElement,
+    Cat\InteractiveElement,
+    Cat\EmbeddedElement {
   use XHPChild\Validation;
   /*
    * The HTML spec permits all non-namespaced attributes
@@ -34,8 +40,6 @@ final xhp class embed extends element {
     bool allowfullscreen,
     enum {'always', 'never'} allowscriptaccess,
     string wmode;
-
-  category %flow, %phrase, %embedded, %interactive;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/e/Embed.hack
+++ b/src/html/tags/e/Embed.hack
@@ -43,7 +43,7 @@ final xhp class embed
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/e/Embed.hack
+++ b/src/html/tags/e/Embed.hack
@@ -14,10 +14,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 final xhp class embed
   extends element
   implements
-    Cat\PhraseElement,
-    Cat\FlowElement,
-    Cat\InteractiveElement,
-    Cat\EmbeddedElement {
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive,
+    Category\Embedded {
   use XHPChild\Validation;
   /*
    * The HTML spec permits all non-namespaced attributes
@@ -43,7 +43,10 @@ final xhp class embed
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/f/Fieldset.hack
+++ b/src/html/tags/f/Fieldset.hack
@@ -11,13 +11,12 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class fieldset extends element {
+final xhp class fieldset extends element implements Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     bool disabled,
     string form,
     string name;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(

--- a/src/html/tags/f/Fieldset.hack
+++ b/src/html/tags/f/Fieldset.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class fieldset extends element implements Cat\FlowElement {
+final xhp class fieldset extends element implements Category\Flow {
   use XHPChild\Validation;
   attribute
     bool disabled,
@@ -22,7 +22,10 @@ final xhp class fieldset extends element implements Cat\FlowElement {
     return XHPChild\sequence(
       XHPChild\optional(XHPChild\of_type<legend>()),
       XHPChild\any_number_of(
-        XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+        XHPChild\any_of(
+          XHPChild\pcdata(),
+          XHPChild\of_type<Category\Flow>(),
+        ),
       ),
     );
   }

--- a/src/html/tags/f/Fieldset.hack
+++ b/src/html/tags/f/Fieldset.hack
@@ -22,7 +22,7 @@ final xhp class fieldset extends element implements Cat\FlowElement {
     return XHPChild\sequence(
       XHPChild\optional(XHPChild\of_type<legend>()),
       XHPChild\any_number_of(
-        XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+        XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
       ),
     );
   }

--- a/src/html/tags/f/Figcaption.hack
+++ b/src/html/tags/f/Figcaption.hack
@@ -16,7 +16,10 @@ final xhp class figcaption extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/f/Figcaption.hack
+++ b/src/html/tags/f/Figcaption.hack
@@ -16,7 +16,7 @@ final xhp class figcaption extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/f/Figure.hack
+++ b/src/html/tags/f/Figure.hack
@@ -13,17 +13,17 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class figure
   extends element
-  implements Cat\FlowElement, Cat\SectioningElement {
+  implements Category\Flow, Category\Sectioning {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_of(
       XHPChild\sequence(
         XHPChild\of_type<figcaption>(),
-        XHPChild\at_least_one_of(XHPChild\of_type<Cat\FlowElement>()),
+        XHPChild\at_least_one_of(XHPChild\of_type<Category\Flow>()),
       ),
       XHPChild\sequence(
-        XHPChild\at_least_one_of(XHPChild\of_type<Cat\FlowElement>()),
+        XHPChild\at_least_one_of(XHPChild\of_type<Category\Flow>()),
         XHPChild\optional(XHPChild\of_type<figcaption>()),
       ),
     );

--- a/src/html/tags/f/Figure.hack
+++ b/src/html/tags/f/Figure.hack
@@ -20,10 +20,10 @@ final xhp class figure
     return XHPChild\any_of(
       XHPChild\sequence(
         XHPChild\of_type<figcaption>(),
-        XHPChild\at_least_one_of(XHPChild\category('%flow')),
+        XHPChild\at_least_one_of(XHPChild\of_type<Cat\FlowElement>()),
       ),
       XHPChild\sequence(
-        XHPChild\at_least_one_of(XHPChild\category('%flow')),
+        XHPChild\at_least_one_of(XHPChild\of_type<Cat\FlowElement>()),
         XHPChild\optional(XHPChild\of_type<figcaption>()),
       ),
     );

--- a/src/html/tags/f/Figure.hack
+++ b/src/html/tags/f/Figure.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class figure extends element {
+final xhp class figure
+  extends element
+  implements Cat\FlowElement, Cat\SectioningElement {
   use XHPChild\Validation;
-  category %flow, %sectioning;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_of(

--- a/src/html/tags/f/Footer.hack
+++ b/src/html/tags/f/Footer.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class footer extends element {
+final xhp class footer extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/f/Footer.hack
+++ b/src/html/tags/f/Footer.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class footer extends element implements Cat\FlowElement {
+final xhp class footer extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/f/Footer.hack
+++ b/src/html/tags/f/Footer.hack
@@ -16,7 +16,7 @@ final xhp class footer extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/f/Form.hack
+++ b/src/html/tags/f/Form.hack
@@ -27,7 +27,7 @@ final xhp class form extends element implements Cat\FlowElement {
   // Should not contain :form
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/f/Form.hack
+++ b/src/html/tags/f/Form.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class form extends element implements Cat\FlowElement {
+final xhp class form extends element implements Category\Flow {
   use XHPChild\Validation;
   attribute
     string action,
@@ -27,7 +27,10 @@ final xhp class form extends element implements Cat\FlowElement {
   // Should not contain :form
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/f/Form.hack
+++ b/src/html/tags/f/Form.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class form extends element {
+final xhp class form extends element implements Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     string action,
@@ -23,7 +23,7 @@ final xhp class form extends element {
     bool novalidate,
     string rel,
     string target;
-  category %flow;
+
   // Should not contain :form
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/h/H1.hack
+++ b/src/html/tags/h/H1.hack
@@ -16,7 +16,7 @@ final xhp class h1 extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/h/H1.hack
+++ b/src/html/tags/h/H1.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h1 extends element {
+final xhp class h1 extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/h/H1.hack
+++ b/src/html/tags/h/H1.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h1 extends element implements Cat\FlowElement {
+final xhp class h1 extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/h/H2.hack
+++ b/src/html/tags/h/H2.hack
@@ -16,7 +16,7 @@ final xhp class h2 extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/h/H2.hack
+++ b/src/html/tags/h/H2.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h2 extends element implements Cat\FlowElement {
+final xhp class h2 extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/h/H2.hack
+++ b/src/html/tags/h/H2.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h2 extends element {
+final xhp class h2 extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/h/H3.hack
+++ b/src/html/tags/h/H3.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h3 extends element implements Cat\FlowElement {
+final xhp class h3 extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/h/H3.hack
+++ b/src/html/tags/h/H3.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h3 extends element {
+final xhp class h3 extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/h/H3.hack
+++ b/src/html/tags/h/H3.hack
@@ -16,7 +16,7 @@ final xhp class h3 extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/h/H4.hack
+++ b/src/html/tags/h/H4.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h4 extends element {
+final xhp class h4 extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/h/H4.hack
+++ b/src/html/tags/h/H4.hack
@@ -16,7 +16,7 @@ final xhp class h4 extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/h/H4.hack
+++ b/src/html/tags/h/H4.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h4 extends element implements Cat\FlowElement {
+final xhp class h4 extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/h/H5.hack
+++ b/src/html/tags/h/H5.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h5 extends element implements Cat\FlowElement {
+final xhp class h5 extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/h/H5.hack
+++ b/src/html/tags/h/H5.hack
@@ -16,7 +16,7 @@ final xhp class h5 extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/h/H5.hack
+++ b/src/html/tags/h/H5.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h5 extends element {
+final xhp class h5 extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/h/H6.hack
+++ b/src/html/tags/h/H6.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h6 extends element {
+final xhp class h6 extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/h/H6.hack
+++ b/src/html/tags/h/H6.hack
@@ -16,7 +16,7 @@ final xhp class h6 extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/h/H6.hack
+++ b/src/html/tags/h/H6.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class h6 extends element implements Cat\FlowElement {
+final xhp class h6 extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/h/Head.hack
+++ b/src/html/tags/h/Head.hack
@@ -15,7 +15,7 @@ final xhp class head extends element {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\any_number_of(XHPChild\category('%metadata'));
+    return XHPChild\any_number_of(XHPChild\of_type<Cat\MetadataElement>());
   }
 
   protected string $tagName = 'head';

--- a/src/html/tags/h/Head.hack
+++ b/src/html/tags/h/Head.hack
@@ -15,7 +15,7 @@ final xhp class head extends element {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\any_number_of(XHPChild\of_type<Cat\MetadataElement>());
+    return XHPChild\any_number_of(XHPChild\of_type<Category\Metadata>());
   }
 
   protected string $tagName = 'head';

--- a/src/html/tags/h/Header.hack
+++ b/src/html/tags/h/Header.hack
@@ -18,7 +18,7 @@ final xhp class header
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/h/Header.hack
+++ b/src/html/tags/h/Header.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class header extends element {
+final xhp class header
+  extends element
+  implements Cat\FlowElement, Cat\HeadingElement {
   use XHPChild\Validation;
-  category %flow, %heading;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/h/Header.hack
+++ b/src/html/tags/h/Header.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class header
   extends element
-  implements Cat\FlowElement, Cat\HeadingElement {
+  implements Category\Flow, Category\Heading {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/h/Hgroup.hack
+++ b/src/html/tags/h/Hgroup.hack
@@ -13,7 +13,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class hgroup
   extends element
-  implements Cat\FlowElement, Cat\HeadingElement {
+  implements Category\Flow, Category\Heading {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {

--- a/src/html/tags/h/Hgroup.hack
+++ b/src/html/tags/h/Hgroup.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class hgroup extends element {
+final xhp class hgroup
+  extends element
+  implements Cat\FlowElement, Cat\HeadingElement {
   use XHPChild\Validation;
-  category %flow, %heading;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(XHPChild\any_of(

--- a/src/html/tags/h/Hr.hack
+++ b/src/html/tags/h/Hr.hack
@@ -9,6 +9,6 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class hr extends singleton implements Cat\FlowElement {
+final xhp class hr extends singleton implements Category\Flow {
   protected string $tagName = 'hr';
 }

--- a/src/html/tags/h/Hr.hack
+++ b/src/html/tags/h/Hr.hack
@@ -9,7 +9,6 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class hr extends singleton {
-  category %flow;
+final xhp class hr extends singleton implements Cat\FlowElement {
   protected string $tagName = 'hr';
 }

--- a/src/html/tags/i/I.hack
+++ b/src/html/tags/i/I.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class i extends element {
+final xhp class i
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/i/I.hack
+++ b/src/html/tags/i/I.hack
@@ -18,7 +18,7 @@ final xhp class i
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/i/I.hack
+++ b/src/html/tags/i/I.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class i
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/i/Iframe.hack
+++ b/src/html/tags/i/Iframe.hack
@@ -12,10 +12,10 @@ namespace Facebook\XHP\HTML;
 final xhp class iframe
   extends pcdata_element
   implements
-    Cat\PhraseElement,
-    Cat\FlowElement,
-    Cat\InteractiveElement,
-    Cat\EmbeddedElement {
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive,
+    Category\Embedded {
   attribute
     string allow,
     bool allowfullscreen,

--- a/src/html/tags/i/Iframe.hack
+++ b/src/html/tags/i/Iframe.hack
@@ -9,7 +9,13 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class iframe extends pcdata_element {
+final xhp class iframe
+  extends pcdata_element
+  implements
+    Cat\PhraseElement,
+    Cat\FlowElement,
+    Cat\InteractiveElement,
+    Cat\EmbeddedElement {
   attribute
     string allow,
     bool allowfullscreen,
@@ -32,6 +38,6 @@ final xhp class iframe extends pcdata_element {
     string src,
     string srcdoc,
     int width;
-  category %flow, %phrase, %embedded, %interactive;
+
   protected string $tagName = 'iframe';
 }

--- a/src/html/tags/i/Img.hack
+++ b/src/html/tags/i/Img.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 final xhp class img
   extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   attribute
     string alt,
     enum {'anonymous', 'use-credentials'} crossorigin,

--- a/src/html/tags/i/Img.hack
+++ b/src/html/tags/i/Img.hack
@@ -9,7 +9,9 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class img extends singleton {
+final xhp class img
+  extends singleton
+  implements Cat\PhraseElement, Cat\FlowElement {
   attribute
     string alt,
     enum {'anonymous', 'use-credentials'} crossorigin,
@@ -33,6 +35,6 @@ final xhp class img extends singleton {
     string srcset,
     string usemap,
     int width;
-  category %flow, %phrase;
+
   protected string $tagName = 'img';
 }

--- a/src/html/tags/i/Input.hack
+++ b/src/html/tags/i/Input.hack
@@ -9,7 +9,9 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class input extends singleton {
+final xhp class input
+  extends singleton
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
   attribute
     string accept,
     string alt,
@@ -65,6 +67,6 @@ final xhp class input extends singleton {
     } type,
     string value,
     int width;
-  category %flow, %phrase, %interactive;
+
   protected string $tagName = 'input';
 }

--- a/src/html/tags/i/Input.hack
+++ b/src/html/tags/i/Input.hack
@@ -11,7 +11,10 @@ namespace Facebook\XHP\HTML;
 
 final xhp class input
   extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive {
   attribute
     string accept,
     string alt,

--- a/src/html/tags/i/Ins.hack
+++ b/src/html/tags/i/Ins.hack
@@ -11,12 +11,13 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class ins extends element {
+final xhp class ins
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     string cite,
     string datetime;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/i/Ins.hack
+++ b/src/html/tags/i/Ins.hack
@@ -13,7 +13,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class ins
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute
     string cite,
@@ -21,7 +21,10 @@ final xhp class ins
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/i/Ins.hack
+++ b/src/html/tags/i/Ins.hack
@@ -21,7 +21,7 @@ final xhp class ins
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/k/Kbd.hack
+++ b/src/html/tags/k/Kbd.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class kbd extends element {
+final xhp class kbd
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/k/Kbd.hack
+++ b/src/html/tags/k/Kbd.hack
@@ -18,7 +18,7 @@ final xhp class kbd
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/k/Kbd.hack
+++ b/src/html/tags/k/Kbd.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class kbd
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/k/Keygen.hack
+++ b/src/html/tags/k/Keygen.hack
@@ -9,13 +9,15 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class keygen extends singleton {
+final xhp class keygen
+  extends singleton
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
   attribute
     string challenge,
     bool disabled,
     string form,
     string keytype,
     string name;
-  category %flow, %phrase, %interactive;
+
   protected string $tagName = 'keygen';
 }

--- a/src/html/tags/k/Keygen.hack
+++ b/src/html/tags/k/Keygen.hack
@@ -11,7 +11,10 @@ namespace Facebook\XHP\HTML;
 
 final xhp class keygen
   extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive {
   attribute
     string challenge,
     bool disabled,

--- a/src/html/tags/l/Label.hack
+++ b/src/html/tags/l/Label.hack
@@ -13,7 +13,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class label
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive {
   use XHPChild\Validation;
   attribute
     string for,
@@ -22,7 +25,10 @@ final xhp class label
   // may not contain label
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/l/Label.hack
+++ b/src/html/tags/l/Label.hack
@@ -11,12 +11,14 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class label extends element {
+final xhp class label
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
   use XHPChild\Validation;
   attribute
     string for,
     string form;
-  category %flow, %phrase, %interactive;
+
   // may not contain label
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/l/Label.hack
+++ b/src/html/tags/l/Label.hack
@@ -22,7 +22,7 @@ final xhp class label
   // may not contain label
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/l/Legend.hack
+++ b/src/html/tags/l/Legend.hack
@@ -16,7 +16,7 @@ final xhp class legend extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/l/Legend.hack
+++ b/src/html/tags/l/Legend.hack
@@ -16,7 +16,10 @@ final xhp class legend extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/l/Li.hack
+++ b/src/html/tags/l/Li.hack
@@ -18,7 +18,10 @@ final xhp class li extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/l/Li.hack
+++ b/src/html/tags/l/Li.hack
@@ -18,7 +18,7 @@ final xhp class li extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/l/Link.hack
+++ b/src/html/tags/l/Link.hack
@@ -9,7 +9,9 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class link extends singleton {
+final xhp class link
+  extends singleton
+  implements Cat\PhraseElement, Cat\MetadataElement, Cat\FlowElement {
   attribute
     string as,
     string color,
@@ -39,6 +41,6 @@ final xhp class link extends singleton {
     string rel @required,
     string sizes,
     string type;
-  category %metadata, %phrase, %flow;
+
   protected string $tagName = 'link';
 }

--- a/src/html/tags/l/Link.hack
+++ b/src/html/tags/l/Link.hack
@@ -11,7 +11,10 @@ namespace Facebook\XHP\HTML;
 
 final xhp class link
   extends singleton
-  implements Cat\PhraseElement, Cat\MetadataElement, Cat\FlowElement {
+  implements
+    Category\Phrase,
+    Category\Metadata,
+    Category\Flow {
   attribute
     string as,
     string color,

--- a/src/html/tags/m/Main.hack
+++ b/src/html/tags/m/Main.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class main extends element implements Cat\FlowElement {
+final xhp class main extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/m/Main.hack
+++ b/src/html/tags/m/Main.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class main extends element {
+final xhp class main extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/m/Main.hack
+++ b/src/html/tags/m/Main.hack
@@ -16,7 +16,7 @@ final xhp class main extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/m/Map.hack
+++ b/src/html/tags/m/Map.hack
@@ -13,13 +13,16 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class map
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute string name;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/m/Map.hack
+++ b/src/html/tags/m/Map.hack
@@ -11,10 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class map extends element {
+final xhp class map
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute string name;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/m/Map.hack
+++ b/src/html/tags/m/Map.hack
@@ -19,7 +19,7 @@ final xhp class map
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/m/Mark.hack
+++ b/src/html/tags/m/Mark.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class mark
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/m/Mark.hack
+++ b/src/html/tags/m/Mark.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class mark extends element {
+final xhp class mark
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/m/Mark.hack
+++ b/src/html/tags/m/Mark.hack
@@ -18,7 +18,7 @@ final xhp class mark
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/m/Menu.hack
+++ b/src/html/tags/m/Menu.hack
@@ -11,12 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class menu extends element {
+final xhp class menu extends element implements Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     string label,
     enum {'popup', 'toolbar'} type;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_of(

--- a/src/html/tags/m/Menu.hack
+++ b/src/html/tags/m/Menu.hack
@@ -25,7 +25,7 @@ final xhp class menu extends element implements Cat\FlowElement {
         XHPChild\of_type<menu>(),
       )),
       XHPChild\any_number_of(XHPChild\of_type<li>()),
-      XHPChild\any_number_of(XHPChild\category('%flow')),
+      XHPChild\any_number_of(XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/m/Menu.hack
+++ b/src/html/tags/m/Menu.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class menu extends element implements Cat\FlowElement {
+final xhp class menu extends element implements Category\Flow {
   use XHPChild\Validation;
   attribute
     string label,
@@ -25,7 +25,7 @@ final xhp class menu extends element implements Cat\FlowElement {
         XHPChild\of_type<menu>(),
       )),
       XHPChild\any_number_of(XHPChild\of_type<li>()),
-      XHPChild\any_number_of(XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_number_of(XHPChild\of_type<Category\Flow>()),
     );
   }
 

--- a/src/html/tags/m/Meta.hack
+++ b/src/html/tags/m/Meta.hack
@@ -9,7 +9,9 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class meta extends singleton {
+final xhp class meta
+  extends singleton
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\MetadataElement {
   attribute
     // The correct definition of http-equiv is an enum, but there are legacy
     // values still used and any strictness here would only be frustrating.
@@ -20,6 +22,6 @@ final xhp class meta extends singleton {
     // Facebook OG
     string property;
   // If itemprop is present, this element is allowed within the <body>.
-  category %metadata, %flow, %phrase;
+
   protected string $tagName = 'meta';
 }

--- a/src/html/tags/m/Meta.hack
+++ b/src/html/tags/m/Meta.hack
@@ -11,7 +11,10 @@ namespace Facebook\XHP\HTML;
 
 final xhp class meta
   extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\MetadataElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Metadata {
   attribute
     // The correct definition of http-equiv is an enum, but there are legacy
     // values still used and any strictness here would only be frustrating.

--- a/src/html/tags/m/Meter.hack
+++ b/src/html/tags/m/Meter.hack
@@ -11,7 +11,9 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class meter extends element {
+final xhp class meter
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     float high,
@@ -20,7 +22,7 @@ final xhp class meter extends element {
     float min,
     float optimum,
     float value;
-  category %flow, %phrase;
+
   // Should not contain :meter
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/m/Meter.hack
+++ b/src/html/tags/m/Meter.hack
@@ -13,7 +13,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class meter
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute
     float high,
@@ -26,7 +26,10 @@ final xhp class meter
   // Should not contain :meter
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/m/Meter.hack
+++ b/src/html/tags/m/Meter.hack
@@ -26,7 +26,7 @@ final xhp class meter
   // Should not contain :meter
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/n/Nav.hack
+++ b/src/html/tags/n/Nav.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class nav extends element {
+final xhp class nav extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/n/Nav.hack
+++ b/src/html/tags/n/Nav.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class nav extends element implements Cat\FlowElement {
+final xhp class nav extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/n/Nav.hack
+++ b/src/html/tags/n/Nav.hack
@@ -16,7 +16,7 @@ final xhp class nav extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/n/Noscript.hack
+++ b/src/html/tags/n/Noscript.hack
@@ -11,7 +11,9 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class noscript extends element {
+final xhp class noscript
+  extends element
+  implements Cat\PhraseElement, Cat\MetadataElement, Cat\FlowElement {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
@@ -22,6 +24,5 @@ final xhp class noscript extends element {
     ));
   }
 
-  category %flow, %phrase, %metadata;
   protected string $tagName = 'noscript';
 }

--- a/src/html/tags/n/Noscript.hack
+++ b/src/html/tags/n/Noscript.hack
@@ -19,8 +19,8 @@ final xhp class noscript
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(XHPChild\any_of(
       XHPChild\pcdata(),
-      XHPChild\category('%metadata'),
-      XHPChild\category('%flow'),
+      XHPChild\of_type<Cat\MetadataElement>(),
+      XHPChild\of_type<Cat\FlowElement>(),
     ));
   }
 

--- a/src/html/tags/n/Noscript.hack
+++ b/src/html/tags/n/Noscript.hack
@@ -13,14 +13,17 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class noscript
   extends element
-  implements Cat\PhraseElement, Cat\MetadataElement, Cat\FlowElement {
+  implements
+    Category\Phrase,
+    Category\Metadata,
+    Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(XHPChild\any_of(
       XHPChild\pcdata(),
-      XHPChild\of_type<Cat\MetadataElement>(),
-      XHPChild\of_type<Cat\FlowElement>(),
+      XHPChild\of_type<Category\Metadata>(),
+      XHPChild\of_type<Category\Flow>(),
     ));
   }
 

--- a/src/html/tags/o/Object.hack
+++ b/src/html/tags/o/Object.hack
@@ -14,10 +14,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 final xhp class object
   extends element
   implements
-    Cat\PhraseElement,
-    Cat\FlowElement,
-    Cat\InteractiveElement,
-    Cat\EmbeddedElement {
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive,
+    Category\Embedded {
   use XHPChild\Validation;
   attribute
     string data,
@@ -33,7 +33,10 @@ final xhp class object
     return XHPChild\sequence(
       XHPChild\any_number_of(XHPChild\of_type<param>()),
       XHPChild\any_number_of(
-        XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+        XHPChild\any_of(
+          XHPChild\pcdata(),
+          XHPChild\of_type<Category\Flow>(),
+        ),
       ),
     );
   }

--- a/src/html/tags/o/Object.hack
+++ b/src/html/tags/o/Object.hack
@@ -33,7 +33,7 @@ final xhp class object
     return XHPChild\sequence(
       XHPChild\any_number_of(XHPChild\of_type<param>()),
       XHPChild\any_number_of(
-        XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+        XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
       ),
     );
   }

--- a/src/html/tags/o/Object.hack
+++ b/src/html/tags/o/Object.hack
@@ -11,7 +11,13 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class object extends element {
+final xhp class object
+  extends element
+  implements
+    Cat\PhraseElement,
+    Cat\FlowElement,
+    Cat\InteractiveElement,
+    Cat\EmbeddedElement {
   use XHPChild\Validation;
   attribute
     string data,
@@ -22,7 +28,6 @@ final xhp class object extends element {
     bool typemustmatch,
     string usemap,
     int width;
-  category %flow, %phrase, %embedded, %interactive;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(

--- a/src/html/tags/o/Ol.hack
+++ b/src/html/tags/o/Ol.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class ol extends element implements Cat\FlowElement {
+final xhp class ol extends element implements Category\Flow {
   use XHPChild\Validation;
   attribute
     bool reversed,

--- a/src/html/tags/o/Ol.hack
+++ b/src/html/tags/o/Ol.hack
@@ -11,13 +11,12 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class ol extends element {
+final xhp class ol extends element implements Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     bool reversed,
     int start,
     enum {'1', 'a', 'A', 'i', 'I'} type;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(XHPChild\of_type<li>());

--- a/src/html/tags/o/Output.hack
+++ b/src/html/tags/o/Output.hack
@@ -22,7 +22,7 @@ final xhp class output
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/o/Output.hack
+++ b/src/html/tags/o/Output.hack
@@ -11,13 +11,14 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class output extends element {
+final xhp class output
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     string for,
     string form,
     string name;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/o/Output.hack
+++ b/src/html/tags/o/Output.hack
@@ -13,7 +13,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class output
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute
     string for,
@@ -22,7 +22,10 @@ final xhp class output
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/p/P.hack
+++ b/src/html/tags/p/P.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class p extends element {
+final xhp class p extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/p/P.hack
+++ b/src/html/tags/p/P.hack
@@ -16,7 +16,7 @@ final xhp class p extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/p/P.hack
+++ b/src/html/tags/p/P.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class p extends element implements Cat\FlowElement {
+final xhp class p extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/p/Picture.hack
+++ b/src/html/tags/p/Picture.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class picture extends element {
+final xhp class picture
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(

--- a/src/html/tags/p/Picture.hack
+++ b/src/html/tags/p/Picture.hack
@@ -13,7 +13,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class picture
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {

--- a/src/html/tags/p/Pre.hack
+++ b/src/html/tags/p/Pre.hack
@@ -16,7 +16,7 @@ final xhp class pre extends element implements Cat\FlowElement {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/p/Pre.hack
+++ b/src/html/tags/p/Pre.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class pre extends element {
+final xhp class pre extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/p/Pre.hack
+++ b/src/html/tags/p/Pre.hack
@@ -11,12 +11,15 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class pre extends element implements Cat\FlowElement {
+final xhp class pre extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/p/Progress.hack
+++ b/src/html/tags/p/Progress.hack
@@ -22,7 +22,7 @@ final xhp class progress
   // Should not contain :progress
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/p/Progress.hack
+++ b/src/html/tags/p/Progress.hack
@@ -11,12 +11,14 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class progress extends element {
+final xhp class progress
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     float max,
     float value;
-  category %flow, %phrase;
+
   // Should not contain :progress
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/p/Progress.hack
+++ b/src/html/tags/p/Progress.hack
@@ -13,7 +13,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class progress
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute
     float max,
@@ -22,7 +22,10 @@ final xhp class progress
   // Should not contain :progress
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/q/Q.hack
+++ b/src/html/tags/q/Q.hack
@@ -11,10 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class q extends element {
+final xhp class q
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute string cite;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/q/Q.hack
+++ b/src/html/tags/q/Q.hack
@@ -19,7 +19,7 @@ final xhp class q
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/q/Q.hack
+++ b/src/html/tags/q/Q.hack
@@ -13,13 +13,16 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class q
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute string cite;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/r/Rb.hack
+++ b/src/html/tags/r/Rb.hack
@@ -16,7 +16,10 @@ final xhp class rb extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/r/Rb.hack
+++ b/src/html/tags/r/Rb.hack
@@ -16,7 +16,7 @@ final xhp class rb extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/r/Rp.hack
+++ b/src/html/tags/r/Rp.hack
@@ -16,7 +16,10 @@ final xhp class rp extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/r/Rp.hack
+++ b/src/html/tags/r/Rp.hack
@@ -16,7 +16,7 @@ final xhp class rp extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/r/Rt.hack
+++ b/src/html/tags/r/Rt.hack
@@ -16,7 +16,10 @@ final xhp class rt extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/r/Rt.hack
+++ b/src/html/tags/r/Rt.hack
@@ -16,7 +16,7 @@ final xhp class rt extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/r/Rtc.hack
+++ b/src/html/tags/r/Rtc.hack
@@ -16,7 +16,10 @@ final xhp class rtc extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/r/Rtc.hack
+++ b/src/html/tags/r/Rtc.hack
@@ -16,7 +16,7 @@ final xhp class rtc extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\at_least_one_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/r/Ruby.hack
+++ b/src/html/tags/r/Ruby.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class ruby extends element {
+final xhp class ruby
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_of(

--- a/src/html/tags/r/Ruby.hack
+++ b/src/html/tags/r/Ruby.hack
@@ -13,7 +13,7 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class ruby
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {

--- a/src/html/tags/s/S.hack
+++ b/src/html/tags/s/S.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class s
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/S.hack
+++ b/src/html/tags/s/S.hack
@@ -18,7 +18,7 @@ final xhp class s
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/S.hack
+++ b/src/html/tags/s/S.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class s extends element {
+final xhp class s
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/s/Samp.hack
+++ b/src/html/tags/s/Samp.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class samp
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Samp.hack
+++ b/src/html/tags/s/Samp.hack
@@ -18,7 +18,7 @@ final xhp class samp
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/Samp.hack
+++ b/src/html/tags/s/Samp.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class samp extends element {
+final xhp class samp
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/s/Script.hack
+++ b/src/html/tags/s/Script.hack
@@ -11,7 +11,10 @@ namespace Facebook\XHP\HTML;
 
 final xhp class script
   extends unescaped_pcdata_element
-  implements Cat\PhraseElement, Cat\MetadataElement, Cat\FlowElement {
+  implements
+    Category\Phrase,
+    Category\Metadata,
+    Category\Flow {
   attribute
     bool async,
     string charset,

--- a/src/html/tags/s/Script.hack
+++ b/src/html/tags/s/Script.hack
@@ -9,7 +9,9 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class script extends unescaped_pcdata_element {
+final xhp class script
+  extends unescaped_pcdata_element
+  implements Cat\PhraseElement, Cat\MetadataElement, Cat\FlowElement {
   attribute
     bool async,
     string charset,
@@ -32,6 +34,6 @@ final xhp class script extends unescaped_pcdata_element {
     string integrity,
     // Legacy
     string language;
-  category %flow, %phrase, %metadata;
+
   protected string $tagName = 'script';
 }

--- a/src/html/tags/s/Section.hack
+++ b/src/html/tags/s/Section.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class section extends element {
+final xhp class section
+  extends element
+  implements Cat\FlowElement, Cat\SectioningElement {
   use XHPChild\Validation;
-  category %flow, %sectioning;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/s/Section.hack
+++ b/src/html/tags/s/Section.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class section
   extends element
-  implements Cat\FlowElement, Cat\SectioningElement {
+  implements Category\Flow, Category\Sectioning {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Section.hack
+++ b/src/html/tags/s/Section.hack
@@ -18,7 +18,7 @@ final xhp class section
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/s/Select.hack
+++ b/src/html/tags/s/Select.hack
@@ -13,7 +13,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class select
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive {
   use XHPChild\Validation;
   attribute
     string autocomplete,

--- a/src/html/tags/s/Select.hack
+++ b/src/html/tags/s/Select.hack
@@ -11,7 +11,9 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class select extends element {
+final xhp class select
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
   use XHPChild\Validation;
   attribute
     string autocomplete,
@@ -21,7 +23,6 @@ final xhp class select extends element {
     string name,
     bool required,
     int size;
-  category %flow, %phrase, %interactive;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/s/Slot.hack
+++ b/src/html/tags/s/Slot.hack
@@ -20,7 +20,7 @@ final xhp class slot
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/Slot.hack
+++ b/src/html/tags/s/Slot.hack
@@ -13,14 +13,17 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class slot
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   attribute string name;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Slot.hack
+++ b/src/html/tags/s/Slot.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class slot extends element {
+final xhp class slot
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   attribute string name;
 

--- a/src/html/tags/s/Small.hack
+++ b/src/html/tags/s/Small.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class small extends element {
+final xhp class small
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/s/Small.hack
+++ b/src/html/tags/s/Small.hack
@@ -18,7 +18,7 @@ final xhp class small
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/Small.hack
+++ b/src/html/tags/s/Small.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class small
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Span.hack
+++ b/src/html/tags/s/Span.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class span extends element {
+final xhp class span
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/s/Span.hack
+++ b/src/html/tags/s/Span.hack
@@ -18,7 +18,7 @@ final xhp class span
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/Span.hack
+++ b/src/html/tags/s/Span.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class span
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Strong.hack
+++ b/src/html/tags/s/Strong.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class strong
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Strong.hack
+++ b/src/html/tags/s/Strong.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class strong extends element {
+final xhp class strong
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/s/Strong.hack
+++ b/src/html/tags/s/Strong.hack
@@ -18,7 +18,7 @@ final xhp class strong
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/Style.hack
+++ b/src/html/tags/s/Style.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 final xhp class style
   extends unescaped_pcdata_element
-  implements Cat\MetadataElement, Cat\FlowElement {
+  implements Category\Metadata, Category\Flow {
   attribute
     string media,
     bool scoped,

--- a/src/html/tags/s/Style.hack
+++ b/src/html/tags/s/Style.hack
@@ -9,11 +9,13 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class style extends unescaped_pcdata_element {
+final xhp class style
+  extends unescaped_pcdata_element
+  implements Cat\MetadataElement, Cat\FlowElement {
   attribute
     string media,
     bool scoped,
     string type;
-  category %flow, %metadata;
+
   protected string $tagName = 'style';
 }

--- a/src/html/tags/s/Sub.hack
+++ b/src/html/tags/s/Sub.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class sub extends element {
+final xhp class sub
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/s/Sub.hack
+++ b/src/html/tags/s/Sub.hack
@@ -18,7 +18,7 @@ final xhp class sub
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/Sub.hack
+++ b/src/html/tags/s/Sub.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class sub
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Summary.hack
+++ b/src/html/tags/s/Summary.hack
@@ -16,7 +16,10 @@ final xhp class summary extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Summary.hack
+++ b/src/html/tags/s/Summary.hack
@@ -16,7 +16,7 @@ final xhp class summary extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/Sup.hack
+++ b/src/html/tags/s/Sup.hack
@@ -18,7 +18,7 @@ final xhp class sup
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/s/Sup.hack
+++ b/src/html/tags/s/Sup.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class sup
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/s/Sup.hack
+++ b/src/html/tags/s/Sup.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class sup extends element {
+final xhp class sup
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/t/Table.hack
+++ b/src/html/tags/t/Table.hack
@@ -11,12 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class table extends element {
+final xhp class table extends element implements Cat\FlowElement {
   use XHPChild\Validation;
   attribute
     int border,
     bool sortable;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(

--- a/src/html/tags/t/Table.hack
+++ b/src/html/tags/t/Table.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class table extends element implements Cat\FlowElement {
+final xhp class table extends element implements Category\Flow {
   use XHPChild\Validation;
   attribute
     int border,

--- a/src/html/tags/t/Td.hack
+++ b/src/html/tags/t/Td.hack
@@ -20,7 +20,7 @@ final xhp class td extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/t/Td.hack
+++ b/src/html/tags/t/Td.hack
@@ -20,7 +20,10 @@ final xhp class td extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/t/Template.hack
+++ b/src/html/tags/t/Template.hack
@@ -9,8 +9,10 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class template extends element {
-  category %flow, %phrase, %metadata;
+final xhp class template
+  extends element
+  implements Cat\PhraseElement, Cat\MetadataElement, Cat\FlowElement {
+
   // The children declaration for this element is extraordinarily verbose so
   // I leave it to you to use it appropriately.
   protected string $tagName = 'template';

--- a/src/html/tags/t/Template.hack
+++ b/src/html/tags/t/Template.hack
@@ -11,7 +11,10 @@ namespace Facebook\XHP\HTML;
 
 final xhp class template
   extends element
-  implements Cat\PhraseElement, Cat\MetadataElement, Cat\FlowElement {
+  implements
+    Category\Phrase,
+    Category\Metadata,
+    Category\Flow {
 
   // The children declaration for this element is extraordinarily verbose so
   // I leave it to you to use it appropriately.

--- a/src/html/tags/t/Textarea.hack
+++ b/src/html/tags/t/Textarea.hack
@@ -9,7 +9,9 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class textarea extends pcdata_element {
+final xhp class textarea
+  extends pcdata_element
+  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
   attribute
     string autocomplete,
     int cols,
@@ -24,6 +26,6 @@ final xhp class textarea extends pcdata_element {
     bool required,
     int rows,
     enum {'soft', 'hard'} wrap;
-  category %flow, %phrase, %interactive;
+
   protected string $tagName = 'textarea';
 }

--- a/src/html/tags/t/Textarea.hack
+++ b/src/html/tags/t/Textarea.hack
@@ -11,7 +11,10 @@ namespace Facebook\XHP\HTML;
 
 final xhp class textarea
   extends pcdata_element
-  implements Cat\PhraseElement, Cat\FlowElement, Cat\InteractiveElement {
+  implements
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive {
   attribute
     string autocomplete,
     int cols,

--- a/src/html/tags/t/Th.hack
+++ b/src/html/tags/t/Th.hack
@@ -23,7 +23,7 @@ final xhp class th extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
     );
   }
 

--- a/src/html/tags/t/Th.hack
+++ b/src/html/tags/t/Th.hack
@@ -23,7 +23,10 @@ final xhp class th extends element {
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Flow>(),
+      ),
     );
   }
 

--- a/src/html/tags/t/Time.hack
+++ b/src/html/tags/t/Time.hack
@@ -19,7 +19,7 @@ final xhp class time
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/t/Time.hack
+++ b/src/html/tags/t/Time.hack
@@ -11,10 +11,11 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class time extends element {
+final xhp class time
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
   attribute string datetime;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/t/Time.hack
+++ b/src/html/tags/t/Time.hack
@@ -13,13 +13,16 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class time
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
   attribute string datetime;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/t/Title.hack
+++ b/src/html/tags/t/Title.hack
@@ -9,6 +9,8 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class title extends pcdata_element implements Cat\MetadataElement {
+final xhp class title
+  extends pcdata_element
+  implements Category\Metadata {
   protected string $tagName = 'title';
 }

--- a/src/html/tags/t/Title.hack
+++ b/src/html/tags/t/Title.hack
@@ -9,7 +9,6 @@
 
 namespace Facebook\XHP\HTML;
 
-final xhp class title extends pcdata_element {
-  category %metadata;
+final xhp class title extends pcdata_element implements Cat\MetadataElement {
   protected string $tagName = 'title';
 }

--- a/src/html/tags/t/Tt.hack
+++ b/src/html/tags/t/Tt.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class tt extends element {
+final xhp class tt
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/t/Tt.hack
+++ b/src/html/tags/t/Tt.hack
@@ -18,7 +18,7 @@ final xhp class tt
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/t/Tt.hack
+++ b/src/html/tags/t/Tt.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class tt
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/u/U.hack
+++ b/src/html/tags/u/U.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class u extends element {
+final xhp class u
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/u/U.hack
+++ b/src/html/tags/u/U.hack
@@ -18,7 +18,7 @@ final xhp class u
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/u/U.hack
+++ b/src/html/tags/u/U.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class u
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/u/Ul.hack
+++ b/src/html/tags/u/Ul.hack
@@ -11,9 +11,8 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class ul extends element {
+final xhp class ul extends element implements Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(XHPChild\of_type<li>());

--- a/src/html/tags/u/Ul.hack
+++ b/src/html/tags/u/Ul.hack
@@ -11,7 +11,7 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class ul extends element implements Cat\FlowElement {
+final xhp class ul extends element implements Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {

--- a/src/html/tags/v/Var.hack
+++ b/src/html/tags/v/Var.hack
@@ -11,9 +11,10 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class var extends element {
+final xhp class var
+  extends element
+  implements Cat\PhraseElement, Cat\FlowElement {
   use XHPChild\Validation;
-  category %flow, %phrase;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(

--- a/src/html/tags/v/Var.hack
+++ b/src/html/tags/v/Var.hack
@@ -13,12 +13,15 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 
 final xhp class var
   extends element
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   use XHPChild\Validation;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
+      XHPChild\any_of(
+        XHPChild\pcdata(),
+        XHPChild\of_type<Category\Phrase>(),
+      ),
     );
   }
 

--- a/src/html/tags/v/Var.hack
+++ b/src/html/tags/v/Var.hack
@@ -18,7 +18,7 @@ final xhp class var
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\any_number_of(
-      XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%phrase')),
+      XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\PhraseElement>()),
     );
   }
 

--- a/src/html/tags/v/Video.hack
+++ b/src/html/tags/v/Video.hack
@@ -38,7 +38,7 @@ final xhp class video
       XHPChild\any_number_of(XHPChild\of_type<source>()),
       XHPChild\any_number_of(XHPChild\of_type<track>()),
       XHPChild\any_number_of(
-        XHPChild\any_of(XHPChild\pcdata(), XHPChild\category('%flow')),
+        XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
       ),
     );
   }

--- a/src/html/tags/v/Video.hack
+++ b/src/html/tags/v/Video.hack
@@ -11,7 +11,13 @@ namespace Facebook\XHP\HTML;
 
 use namespace Facebook\XHP\ChildValidation as XHPChild;
 
-final xhp class video extends element {
+final xhp class video
+  extends element
+  implements
+    Cat\PhraseElement,
+    Cat\FlowElement,
+    Cat\InteractiveElement,
+    Cat\EmbeddedElement {
   use XHPChild\Validation;
   attribute
     bool autoplay,
@@ -26,7 +32,6 @@ final xhp class video extends element {
     enum {'none', 'metadata', 'auto'} preload,
     string src,
     int width;
-  category %flow, %phrase, %embedded, %interactive;
 
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
     return XHPChild\sequence(

--- a/src/html/tags/v/Video.hack
+++ b/src/html/tags/v/Video.hack
@@ -14,10 +14,10 @@ use namespace Facebook\XHP\ChildValidation as XHPChild;
 final xhp class video
   extends element
   implements
-    Cat\PhraseElement,
-    Cat\FlowElement,
-    Cat\InteractiveElement,
-    Cat\EmbeddedElement {
+    Category\Phrase,
+    Category\Flow,
+    Category\Interactive,
+    Category\Embedded {
   use XHPChild\Validation;
   attribute
     bool autoplay,
@@ -38,7 +38,10 @@ final xhp class video
       XHPChild\any_number_of(XHPChild\of_type<source>()),
       XHPChild\any_number_of(XHPChild\of_type<track>()),
       XHPChild\any_number_of(
-        XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<Cat\FlowElement>()),
+        XHPChild\any_of(
+          XHPChild\pcdata(),
+          XHPChild\of_type<Category\Flow>(),
+        ),
       ),
     );
   }

--- a/src/html/tags/w/Wbr.hack
+++ b/src/html/tags/w/Wbr.hack
@@ -11,6 +11,6 @@ namespace Facebook\XHP\HTML;
 
 final xhp class wbr
   extends singleton
-  implements Cat\PhraseElement, Cat\FlowElement {
+  implements Category\Phrase, Category\Flow {
   protected string $tagName = 'wbr';
 }

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -13,6 +13,13 @@ use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace HH\Lib\C;
 
+xhp class not_primitive extends x\element {
+  <<__Override>>
+  public async function renderAsync(): Awaitable<div> {
+    return <div><div>I am not a primitive</div></div>;
+  }
+}
+
 xhp class test:renders_primitive extends x\element {
   <<__Override>>
   protected async function renderAsync(): Awaitable<x\node> {
@@ -27,6 +34,37 @@ class BasicsTest extends Facebook\HackTest\HackTest {
         Hello, world.
       </div>;
     expect(await $xhp->toStringAsync())->toEqual('<div> Hello, world. </div>');
+  }
+
+  public async function testCertainActionAreProhibitedAfterRender(
+  ): Awaitable<void> {
+    $not_primitive = <not_primitive />;
+    await $not_primitive->toStringAsync();
+    expect(() ==> $not_primitive->setAttribute('class', 'already-rendered'))
+      ->toThrow(InvariantException::class, 'after render');
+
+    $div = <div />;
+    await $div->toStringAsync();
+    expect(() ==> $div->setAttribute('class', 'already-rendered'))->toThrow(
+      InvariantException::class,
+      'after render',
+    );
+  }
+
+  public async function testRenderingAnElementTwiceThrows(): Awaitable<void> {
+    $div = <div />;
+    await $div->toStringAsync();
+    expect(() ==> $div->toStringAsync())->toThrow(
+      InvariantException::class,
+      'render XHP element twice',
+    );
+
+    $not_primitive = <not_primitive />;
+    await $not_primitive->toStringAsync();
+    expect(() ==> $not_primitive->toStringAsync())->toThrow(
+      InvariantException::class,
+      'render XHP element twice',
+    );
   }
 
   public async function testFragWithString(): Awaitable<void> {

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -8,7 +8,7 @@
  */
 
 use namespace Facebook\XHP\Core as x;
-use type Facebook\XHP\HTML\{br, div, head, img, singleton, style};
+use type Facebook\XHP\HTML\{br, div, h1, h2, h3, head, img, singleton, style};
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace HH\Lib\C;
@@ -131,5 +131,51 @@ class BasicsTest extends Facebook\HackTest\HackTest {
     expect(
       await (<head><style>{$dangerous_chars}</style></head>)->toStringAsync(),
     )->toEqual('<head><style>'.$dangerous_chars.'</style></head>');
+  }
+
+  public function testSelectingChildren(): void {
+    $empty = <div></div>;
+    $one = <h1 />;
+    $two = <h2 />;
+    $three = <h3 />;
+    $four = <h2 />;
+    $five = <h1 />;
+    $full = <div>{vec[$one, $two, $three, $four, $five]}</div>;
+
+    expect($empty->getFirstChild())->toBeNull();
+    expect($empty->getFirstChild(''))->toBeNull();
+    expect($empty->getFirstChild(h2::class))->toBeNull();
+    expect($empty->getLastChild())->toBeNull();
+    expect($empty->getLastChild(''))->toBeNull();
+    expect($empty->getLastChild(h2::class))->toBeNull();
+
+    expect($full->getFirstChild())->toEqual($one);
+    // This differs from getChildren(), which treats empty string as wildcards (like null)
+    expect($full->getFirstChild(''))->toBeNull();
+    expect($full->getFirstChild(h2::class))->toEqual($two);
+    // Watch out, this is a painful BC break.
+    // The typechecker won't warn you that the class is not named h2.
+    // You need to pass Facebook\XHP\HTML\h2 (h2::class)
+    expect($full->getFirstChild('h2'))->toBeNull();
+
+    expect($full->getLastChild())->toEqual($five);
+    // This uses getChildren() under the hood.
+    // So empty string /is/ a wildcard here.
+    // Let's make this consistent before v4 is set in stone.
+    expect($full->getLastChild(''))->toEqual($five);
+    expect($full->getLastChild(h2::class))->toEqual($four);
+    expect($full->getFirstChild('h2'))->toBeNull();
+
+    expect($empty->getFirstChildOfType<h2>())->toBeNull();
+    expect($empty->getLastChildOfType<h2>())->toBeNull();
+    expect($full->getFirstChildOfType<h2>())->toEqual($two);
+    expect($full->getLastChildOfType<h2>())->toEqual($four);
+    expect($full->getFirstChildOfType<h1>())->toEqual($one);
+    expect($full->getLastChildOfType<h1>())->toEqual($five);
+    expect($full->getLastChildOfType<br>())->toBeNull();
+
+    expect($empty->getChildrenOfType<h1>())->toBeEmpty();
+    expect($full->getChildrenOfType<h1>())->toEqual(vec[$one, $five]);
+    expect($full->getChildrenOfType<br>())->toBeEmpty();
   }
 }

--- a/tests/ChildRuleTest.hack
+++ b/tests/ChildRuleTest.hack
@@ -226,6 +226,7 @@ xhp class test:category_child extends x\element {
 }
 
 xhp class test:has_comma_category extends x\element {
+  // Can not be foo:bar_DEPRECATED, because of mangling
   category %foo:bar;
 
   <<__Override>>
@@ -299,11 +300,26 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       tuple(<test:optional_child />, '\\'.div::class.'?'),
       tuple(<test:any_number_of_child />, '\\'.div::class.'*'),
       tuple(<test:at_least_one_child />, '\\'.div::class.'+'),
-      tuple(<test:two_children />, Str\format('\\%s,\\%s', div::class, div::class)),
-      tuple(<test:three_children />, Str\format('\\%s,\\%s,\\%s', div::class, div::class, div::class)),
-      tuple(<test:either_of_two_children />, Str\format('\\%s|\\%s', div::class, code::class)),
-      tuple(<test:any_of_three_children />,  Str\format('\\%s|\\%s|\\%s', div::class ,code::class, p::class)),
-      tuple(<test:nested_rule />, Str\format('\\%s|\\%s+', div::class, code::class)),
+      tuple(
+        <test:two_children />,
+        Str\format('\\%s,\\%s', div::class, div::class),
+      ),
+      tuple(
+        <test:three_children />,
+        Str\format('\\%s,\\%s,\\%s', div::class, div::class, div::class),
+      ),
+      tuple(
+        <test:either_of_two_children />,
+        Str\format('\\%s|\\%s', div::class, code::class),
+      ),
+      tuple(
+        <test:any_of_three_children />,
+        Str\format('\\%s|\\%s|\\%s', div::class, code::class, p::class),
+      ),
+      tuple(
+        <test:nested_rule />,
+        Str\format('\\%s|\\%s+', div::class, code::class),
+      ),
       tuple(<testpcdata_child />, 'pcdata'),
       tuple(<test:category_child />, '%flow'),
     ];

--- a/tests/ChildRuleTest.hack
+++ b/tests/ChildRuleTest.hack
@@ -9,7 +9,7 @@
 
 use namespace Facebook\XHP\Core as x;
 use type Facebook\XHP\HTML\{code, div, p, thead};
-
+use namespace Facebook\XHP\HTML\Cat;
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace Facebook\XHP\ChildValidation as XHPChild;
@@ -213,10 +213,10 @@ xhp class testpcdata_child extends x\element {
   }
 }
 
-xhp class test:category_child extends x\element {
+xhp class test:category_interface_child extends x\element {
   use XHPChild\Validation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\category('%flow');
+    return XHPChild\of_type<Cat\FlowElement>();
   }
 
   <<__Override>>
@@ -278,7 +278,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       <test:either_of_two_children />,
       <test:any_of_three_children />,
       <test:nested_rule />,
-      <test:category_child />,
+      <test:category_interface_child />,
     ];
     foreach ($elems as $elem) {
       $elem->appendChild(<div>Foo</div>);
@@ -321,7 +321,10 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
         Str\format('\\%s|\\%s+', div::class, code::class),
       ),
       tuple(<testpcdata_child />, 'pcdata'),
-      tuple(<test:category_child />, '%flow'),
+      tuple(
+        <test:category_interface_child />,
+        '\Facebook\XHP\HTML\Cat\FlowElement',
+      ),
     ];
   }
 
@@ -347,7 +350,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       <test:three_children />,
       <test:either_of_two_children />,
       <test:nested_rule />,
-      <test:category_child />,
+      <test:category_interface_child />,
     ];
     foreach ($elems as $elem) {
       $elem->appendChild(<x:frag><div /><div /><div /><div /></x:frag>);
@@ -365,7 +368,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       <test:either_of_two_children />,
       <test:any_of_three_children />,
       <test:nested_rule />,
-      <test:category_child />,
+      <test:category_interface_child />,
     ];
     foreach ($elems as $elem) {
       $exception = null;

--- a/tests/ChildRuleTest.hack
+++ b/tests/ChildRuleTest.hack
@@ -9,7 +9,7 @@
 
 use namespace Facebook\XHP\Core as x;
 use type Facebook\XHP\HTML\{code, div, p, thead};
-use namespace Facebook\XHP\HTML\Cat;
+use namespace Facebook\XHP\HTML\Category;
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace Facebook\XHP\ChildValidation as XHPChild;
@@ -216,7 +216,7 @@ xhp class testpcdata_child extends x\element {
 xhp class test:category_interface_child extends x\element {
   use XHPChild\Validation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
-    return XHPChild\of_type<Cat\FlowElement>();
+    return XHPChild\of_type<Category\Flow>();
   }
 
   <<__Override>>
@@ -323,7 +323,7 @@ class ChildRuleTest extends Facebook\HackTest\HackTest {
       tuple(<testpcdata_child />, 'pcdata'),
       tuple(
         <test:category_interface_child />,
-        '\Facebook\XHP\HTML\Cat\FlowElement',
+        '\Facebook\XHP\HTML\Category\Flow',
       ),
     ];
   }

--- a/tests/ReflectionTest.hack
+++ b/tests/ReflectionTest.hack
@@ -36,7 +36,7 @@ xhp class test:for_reflection extends x\element {
     );
   }
 
-  category %herp, %derp;
+  category %herp_DEPRECATED, %derp_DEPRECATED;
 
   <<__Override>>
   public async function renderAsync(): Awaitable<x\node> {
@@ -66,7 +66,8 @@ class ReflectionTest extends Facebook\HackTest\HackTest {
     $children = $this->rxc?->getChildren();
     expect($children)->toBeInstanceOf(ReflectionXHPChildrenDeclaration::class);
     expect($children?->__toString())->toEqual(
-      Str\format('\\%s+,(\\%s,\\%s)?', div::class, code::class, a::class));
+      Str\format('\\%s+,(\\%s,\\%s)?', div::class, code::class, a::class),
+    );
   }
 
   public function testGetAttributes(): void {
@@ -84,6 +85,6 @@ class ReflectionTest extends Facebook\HackTest\HackTest {
 
   public function testGetCategories(): void {
     $categories = $this->rxc?->getCategories();
-    expect($categories)->toEqual(keyset['herp', 'derp']);
+    expect($categories)->toEqual(keyset['herp_DEPRECATED', 'derp_DEPRECATED']);
   }
 }


### PR DESCRIPTION
Support for `%categories` has not been removed from xhp, but we are nudging toward interfaces.
Categories are not types and are therefore not typechecked.
It is very easy to typo `%pharse` and debug child validation exceptions.