### PR TITLE
Fix some perceived problems with __isRendered

### DIFF
--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -91,7 +91,7 @@ abstract xhp class node implements \XHPChild {
    * @param $child     single child or a Traversable of children
    */
   final public function appendChild(mixed $child): this {
-    invariant(!$this->__isRendered, "Can't appendChild after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     if ($child is Traversable<_>) {
       foreach ($child as $c) {
         $this->appendChild($c);
@@ -113,7 +113,7 @@ abstract xhp class node implements \XHPChild {
    * @param $children  single child or a Traversable of children
    */
   final public function replaceChildren(\XHPChild ...$children): this {
-    invariant(!$this->__isRendered, "Can't appendChild after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     // This function has been micro-optimized
     $new_children = vec[];
     foreach ($children as $xhp) {
@@ -339,7 +339,7 @@ abstract xhp class node implements \XHPChild {
    * @param $val       value
    */
   final public function setAttribute(string $attr, mixed $value): this {
-    invariant(!$this->__isRendered, "Can't setAttribute after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     $this->attributes[$attr] = $value;
     return $this;
   }
@@ -374,7 +374,7 @@ abstract xhp class node implements \XHPChild {
    * @param $attr      attribute to remove
    */
   final public function removeAttribute(string $attr): this {
-    invariant(!$this->__isRendered, "Can't removeAttribute after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     unset($this->attributes[$attr]);
     return $this;
   }
@@ -389,7 +389,7 @@ abstract xhp class node implements \XHPChild {
    * @param $val       value
    */
   final public function forceAttribute(string $attr, mixed $value): this {
-    invariant(!$this->__isRendered, "Can't forceAttribute after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     $this->attributes[$attr] = $value;
     return $this;
   }
@@ -429,7 +429,7 @@ abstract xhp class node implements \XHPChild {
    * @return           $this
    */
   final public function setContext(string $key, mixed $value): this {
-    invariant(!$this->__isRendered, "Can't setContext after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     $this->context[$key] = $value;
     return $this;
   }
@@ -447,7 +447,7 @@ abstract xhp class node implements \XHPChild {
   final public function addContextMap(
     KeyedContainer<string, mixed> $context,
   ): this {
-    invariant(!$this->__isRendered, "Can't setContext after render");
+    invariant(!$this->__isRendered, "Can't %s after render", __FUNCTION__);
     $this->context = Dict\merge($this->context, $context);
     return $this;
   }

--- a/src/core/Primitive.hack
+++ b/src/core/Primitive.hack
@@ -22,6 +22,7 @@ abstract xhp class primitive extends node {
 
   <<__Override>>
   final public async function toStringAsync(): Awaitable<string> {
+    invariant(!$this->__isRendered, 'Attempted to render XHP element twice');
     $that = await $this->__flushSubtree();
     $result = await $that->stringifyAsync();
     $this->__isRendered = true;

--- a/src/core/Primitive.hack
+++ b/src/core/Primitive.hack
@@ -23,7 +23,9 @@ abstract xhp class primitive extends node {
   <<__Override>>
   final public async function toStringAsync(): Awaitable<string> {
     $that = await $this->__flushSubtree();
-    return await $that->stringifyAsync();
+    $result = await $that->stringifyAsync();
+    $this->__isRendered = true;
+    return $result;
   }
 
   final private async function __flushElementChildren(): Awaitable<void> {

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -51,6 +51,22 @@ class BasicsTest extends Facebook\HackTest\HackTest {
     );
   }
 
+  public async function testRenderingAnElementTwiceThrows(): Awaitable<void> {
+    $div = <div />;
+    await $div->toStringAsync();
+    expect(() ==> $div->toStringAsync())->toThrow(
+      InvariantException::class,
+      'render XHP element twice',
+    );
+
+    $not_primitive = <not_primitive />;
+    await $not_primitive->toStringAsync();
+    expect(() ==> $not_primitive->toStringAsync())->toThrow(
+      InvariantException::class,
+      'render XHP element twice',
+    );
+  }
+
   public async function testFragWithString(): Awaitable<void> {
     $xhp = <x:frag>Derp</x:frag>;
     expect(await $xhp->toStringAsync())->toEqual('Derp');

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -13,6 +13,13 @@ use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace HH\Lib\C;
 
+xhp class not_primitive extends x\element {
+  <<__Override>>
+  public async function renderAsync(): Awaitable<div> {
+    return <div><div>I am not a primitive</div></div>;
+  }
+}
+
 xhp class test:renders_primitive extends x\element {
   <<__Override>>
   protected async function renderAsync(): Awaitable<x\node> {
@@ -27,6 +34,21 @@ class BasicsTest extends Facebook\HackTest\HackTest {
         Hello, world.
       </div>;
     expect(await $xhp->toStringAsync())->toEqual('<div> Hello, world. </div>');
+  }
+
+  public async function testCertainActionAreProhibitedAfterRender(
+  ): Awaitable<void> {
+    $not_primitive = <not_primitive />;
+    await $not_primitive->toStringAsync();
+    expect(() ==> $not_primitive->setAttribute('class', 'already-rendered'))
+      ->toThrow(InvariantException::class, 'after render');
+
+    $div = <div />;
+    await $div->toStringAsync();
+    expect(() ==> $div->setAttribute('class', 'already-rendered'))->toThrow(
+      InvariantException::class,
+      'after render',
+    );
   }
 
   public async function testFragWithString(): Awaitable<void> {


### PR DESCRIPTION
 - The exception messages mentioned methods as string literals.
   These did not always match the actual method name.
 - The __isRendered flag was not set for primitives.
   This might have been intentional.
   If it is, revert the changes in primitive.
   However, it is strange to allow ->setAttribute() after render on div,
   but prohibit it on ui:div.