### PR TITLE
Constrain `getFirstChildOfType` etc to `XHPChild`

### DIFF
--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -159,7 +159,7 @@ abstract xhp class node implements \XHPChild {
   /**
    * Fetches all direct children of this element of the given type.
    */
-  public function getChildrenOfType<<<__Enforceable>> reify T>(): vec<T> {
+  public function getChildrenOfType<<<__Enforceable>> reify T as \XHPChild>(): vec<T> {
     $children = vec[];
     foreach ($this->children as $child) {
       if ($child is T) {
@@ -195,7 +195,7 @@ abstract xhp class node implements \XHPChild {
    *
    * If no matching child is present, returns `null`.
    */
-  public function getFirstChildOfType<<<__Enforceable>> reify T>(): ?T {
+  public function getFirstChildOfType<<<__Enforceable>> reify T as \XHPChild>(): ?T {
     foreach ($this->children as $child) {
       if ($child is T) {
         return $child;
@@ -209,7 +209,7 @@ abstract xhp class node implements \XHPChild {
    *
    * If no matching child is present, an exception is thrown.
    */
-  public function getFirstChildOfTypex<<<__Enforceable>> reify T>(): T {
+  public function getFirstChildOfTypex<<<__Enforceable>> reify T as \XHPChild>(): T {
     $child = $this->getFirstChildOfType<T>();
     invariant(
       $child is nonnull,
@@ -246,7 +246,7 @@ abstract xhp class node implements \XHPChild {
    *
    * If the element has no matching children, `null` is returned.
    */
-  public function getLastChildOfType<<<__Enforceable>> reify T>(): ?T {
+  public function getLastChildOfType<<<__Enforceable>> reify T as \XHPChild>(): ?T {
     for ($i = C\count($this->children) - 1; $i >= 0; --$i) {
       $child = $this->children[$i];
       if ($child is T) {
@@ -261,9 +261,9 @@ abstract xhp class node implements \XHPChild {
    *
    * If the element has no matching children, an exception is thrown.
    */
-  public function getLastChildOfTypex<<<__Enforceable>> reify T>(): T {
+  public function getLastChildOfTypex<<<__Enforceable>> reify T as \XHPChild>(): T {
     $child = $this->getLastChildOfType<T>();
-    invariant($child is nonnull, 'No such child');
+    invariant($child is nonnull, '%s called with no matching child', __FUNCTION__);
     return $child;
   }
 

--- a/src/html/categories/Category.hack
+++ b/src/html/categories/Category.hack
@@ -9,4 +9,5 @@
 
 namespace Facebook\XHP\HTML\Category;
 
-interface Phrase extends Category {}
+interface Category extends \XHPChild {
+}

--- a/src/html/categories/Embedded.hack
+++ b/src/html/categories/Embedded.hack
@@ -9,4 +9,4 @@
 
 namespace Facebook\XHP\HTML\Category;
 
-interface Embedded {}
+interface Embedded extends Category {}

--- a/src/html/categories/Flow.hack
+++ b/src/html/categories/Flow.hack
@@ -9,4 +9,4 @@
 
 namespace Facebook\XHP\HTML\Category;
 
-interface Flow {}
+interface Flow extends Category {}

--- a/src/html/categories/Heading.hack
+++ b/src/html/categories/Heading.hack
@@ -9,4 +9,4 @@
 
 namespace Facebook\XHP\HTML\Category;
 
-interface Heading {}
+interface Heading extends Category {}

--- a/src/html/categories/Interactive.hack
+++ b/src/html/categories/Interactive.hack
@@ -9,4 +9,4 @@
 
 namespace Facebook\XHP\HTML\Category;
 
-interface Interactive {}
+interface Interactive extends Category {}

--- a/src/html/categories/Metadata.hack
+++ b/src/html/categories/Metadata.hack
@@ -9,4 +9,4 @@
 
 namespace Facebook\XHP\HTML\Category;
 
-interface Metadata {}
+interface Metadata extends Category {}

--- a/src/html/categories/Sectioning.hack
+++ b/src/html/categories/Sectioning.hack
@@ -9,4 +9,4 @@
 
 namespace Facebook\XHP\HTML\Category;
 
-interface Sectioning {}
+interface Sectioning extends Category {}

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -8,7 +8,8 @@
  */
 
 use namespace Facebook\XHP\Core as x;
-use type Facebook\XHP\HTML\{br, div, h1, h2, h3, head, img, singleton, style};
+use type Facebook\XHP\HTML\{body, br, details, div, h1, h2, h3, head, html, img, p, script, singleton, style};
+use namespace Facebook\XHP\HTML\Category;
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 use namespace HH\Lib\C;
@@ -161,5 +162,23 @@ class BasicsTest extends Facebook\HackTest\HackTest {
     expect($empty->getChildrenOfType<h1>())->toBeEmpty();
     expect($full->getChildrenOfType<h1>())->toEqual(vec[$one, $five]);
     expect($full->getChildrenOfType<br>())->toBeEmpty();
+
+    $one = <details />;
+    $two = <script />;
+    $three = <details />;
+    $full = <div>{$one}{$two}{$three}</div>;
+    expect($full->getFirstChildOfType<Category\Interactive>())->toEqual($one);
+    expect($full->getFirstChildOfType<Category\Metadata>())->toEqual($two);
+    expect($full->getLastChildOfType<Category\Interactive>())->toEqual($three);
+    expect($full->getLastChildOfType<Category\Metadata>())->toEqual($two);
+
+    $body = <body />;
+    $html = <html>{$body}</html>;
+    // The intent is to make sure that `OfType` still works even if the
+    // element does not implement any categories. If body starts
+    // implementing categories, pick a different element - don't change
+    // this expectation.
+    expect($body is \Facebook\XHP\HTML\Category\Category)->toBeFalse();
+    expect($html->getFirstChildOfType<body>())->toEqual($body);
   }
 }


### PR DESCRIPTION
- add base interface for HTML categories that explicitly extends it
- add unit test for this new functionality

Using `<detail>` and `<script>` as more common classes do not have
the expected categories (#273)
