### PR TITLE
Add an XHPPath to UseAfterRenderExceptions

### DIFF
--- a/src/core/Element.hack
+++ b/src/core/Element.hack
@@ -33,7 +33,6 @@ abstract xhp class element extends node {
     }
     try {
       $that = await $this->__flushRenderedRootElement();
-      $this->__isRendered = true;
       return await $that->toStringAsync();
     } catch (UseAfterRenderException $e) {
       $e->__viaXHPPath(static::class);

--- a/src/core/Element.hack
+++ b/src/core/Element.hack
@@ -36,8 +36,13 @@ abstract xhp class element extends node {
    */
   <<__Override>>
   final protected async function __flushSubtree(): Awaitable<primitive> {
-    $that = await $this->__flushRenderedRootElement();
-    return await $that->__flushSubtree();
+    try {
+      $that = await $this->__flushRenderedRootElement();
+      return await $that->__flushSubtree();
+    } catch (UseAfterRenderException $e) {
+      $e->__viaXHPPath(static::class);
+      throw $e;
+    }
   }
 
   /**

--- a/src/core/Element.hack
+++ b/src/core/Element.hack
@@ -26,9 +26,19 @@ abstract xhp class element extends node {
    */
   <<__Override>>
   final public async function toStringAsync(): Awaitable<string> {
-    $that = await $this->__flushRenderedRootElement();
-    $ret = await $that->toStringAsync();
-    return $ret;
+    if ($this->__isRendered) {
+      throw new UseAfterRenderException(
+        'Attempted to render XHP element twice',
+      );
+    }
+    try {
+      $that = await $this->__flushRenderedRootElement();
+      $this->__isRendered = true;
+      return await $that->toStringAsync();
+    } catch (UseAfterRenderException $e) {
+      $e->__viaXHPPath(static::class);
+      throw $e;
+    }
   }
 
   /**

--- a/src/core/Primitive.hack
+++ b/src/core/Primitive.hack
@@ -51,12 +51,22 @@ abstract xhp class primitive extends node {
         $children[$idx] = $child;
       }
     }
+    if ($this->__isRendered) {
+      throw new UseAfterRenderException(
+        'Attempted to render XHP element twice',
+      );
+    }
     $this->replaceChildren($children);
   }
 
   <<__Override>>
   final protected async function __flushSubtree(): Awaitable<primitive> {
-    await $this->__flushElementChildren();
+    try {
+      await $this->__flushElementChildren();
+    } catch (UseAfterRenderException $e) {
+      $e->__viaXHPPath(static::class);
+      throw $e;
+    }
     if (\Facebook\XHP\ChildValidation\is_enabled()) {
       $this->validateChildren();
     }

--- a/src/core/UseAfterRenderException.hack
+++ b/src/core/UseAfterRenderException.hack
@@ -21,6 +21,7 @@ final class UseAfterRenderException extends \InvalidOperationException {
     $this->xhpPath = Vec\concat(vec[$node], $this->xhpPath);
   }
 
+  <<__Override>>
   public function getMessage(): string {
     if (C\is_empty($this->xhpPath)) {
       return $this->message;

--- a/src/core/UseAfterRenderException.hack
+++ b/src/core/UseAfterRenderException.hack
@@ -8,5 +8,27 @@
  */
 
 namespace Facebook\XHP\Core;
+use namespace HH\Lib\{C, Str, Vec};
 
-final class UseAfterRenderException extends \InvalidOperationException {}
+final class UseAfterRenderException extends \InvalidOperationException {
+  private vec<classname<node>> $xhpPath = vec[];
+
+  public function __construct(string $message) {
+    parent::__construct($message);
+  }
+
+  public function __viaXHPPath(classname<node> $node): void {
+    $this->xhpPath = Vec\concat(vec[$node], $this->xhpPath);
+  }
+
+  public function getMessage(): string {
+    if (C\is_empty($this->xhpPath)) {
+      return $this->message;
+    }
+    return Vec\map(
+      $this->xhpPath,
+      $class ==> Str\strip_prefix($class, 'Facebook\\XHP\\'),
+    )
+      |> $this->message."\nVia XHPPath: ".Str\join($$, ' -> ').'.';
+  }
+}

--- a/src/core/UseAfterRenderException.hack
+++ b/src/core/UseAfterRenderException.hack
@@ -18,7 +18,7 @@ final class UseAfterRenderException extends \InvalidOperationException {
   }
 
   public function __viaXHPPath(classname<node> $node): void {
-    $this->xhpPath = Vec\concat(vec[$node], $this->xhpPath);
+    $this->xhpPath[] = $node;
   }
 
   <<__Override>>
@@ -26,10 +26,8 @@ final class UseAfterRenderException extends \InvalidOperationException {
     if (C\is_empty($this->xhpPath)) {
       return $this->message;
     }
-    return Vec\map(
-      $this->xhpPath,
-      $class ==> Str\strip_prefix($class, 'Facebook\\XHP\\'),
-    )
+    return Vec\reverse($this->xhpPath)
+      |> Vec\map($$, $class ==> Str\strip_prefix($class, 'Facebook\\XHP\\'))
       |> $this->message."\nVia XHPPath: ".Str\join($$, ' -> ').'.';
   }
 }

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -96,7 +96,9 @@ class BasicsTest extends Facebook\HackTest\HackTest {
   public function provideFaultyTrees(): vec<(x\node, string)> {
     $br = <br />;
     $ui_div = <ui:div><div><span /></div></ui:div>;
+    /*HHAST_IGNORE_ERROR[DontUseAsioJoin]*/
     \HH\Asio\join($br->toStringAsync());
+    /*HHAST_IGNORE_ERROR[DontUseAsioJoin]*/
     \HH\Asio\join($ui_div->toStringAsync());
 
     return vec[

--- a/tests/BasicsTest.hack
+++ b/tests/BasicsTest.hack
@@ -46,6 +46,13 @@ xhp class ui:div extends x\element {
   }
 }
 
+xhp class ui:returning:ui extends x\element {
+  <<__Override>>
+  public async function renderAsync(): Awaitable<ui\div> {
+    return <ui:div>{$this->getChildren()}</ui:div>;
+  }
+}
+
 xhp class test:renders_primitive extends x\element {
   <<__Override>>
   protected async function renderAsync(): Awaitable<x\node> {
@@ -123,6 +130,11 @@ class BasicsTest extends Facebook\HackTest\HackTest {
         'Via XHPPath: HTML\\div -> HTML\\span -> ui\\div.',
       ),
       tuple(
+        <ui:div><span>{$ui_div}</span></ui:div>,
+        // Custom element at the start of the chain
+        'Via XHPPath: ui\\div -> HTML\\div -> HTML\\span -> ui\\div.',
+      ),
+      tuple(
         <div>
           <span />
           <div><span /></div>
@@ -138,6 +150,11 @@ class BasicsTest extends Facebook\HackTest\HackTest {
         </div>,
         // Custom inside of custom
         'Via XHPPath: HTML\\div -> ui\\div -> HTML\\div -> ui\\div -> HTML\\div -> HTML\span -> HTML\\br.',
+      ),
+      tuple(
+        <ui:returning:ui><span>{$br}</span></ui:returning:ui>,
+        // Limitation a ui:div is missing V here, because Element::__flushRenderedRootElement loops until a primitive
+        'Via XHPPath: ui\\returning\\ui -> HTML\\div -> HTML\span -> HTML\\br.',
       ),
     ];
   }


### PR DESCRIPTION
thrown deep inside of rendered trees

refers to https://github.com/hhvm/xhp-lib/issues/279#issue-673009008