### PR TITLE
Rename UnsafeAttributeValue to UnsafeAttributeValue_DEPRECATED

### DIFF
--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -459,7 +459,7 @@ abstract xhp class node implements \XHPChild {
    * @deprecated This functionality will be removed in a future release.
    *
    * This has not yet been removed as it is currently the only way to
-   * set an `UnsafeAttributeValue`.
+   * set an `UnsafeAttributeValue_DEPRECATED`.
    *
    * Sets an attribute in this element's attribute store. Always foregoes
    * validation.

--- a/src/core/UnsafeAttributeValue_DEPRECATED.hack
+++ b/src/core/UnsafeAttributeValue_DEPRECATED.hack
@@ -18,7 +18,7 @@ namespace Facebook\XHP;
  *
  * This must be used via `forceAttribute()`.
  */
-abstract class UnsafeAttributeValue {
+abstract class UnsafeAttributeValue_DEPRECATED {
   abstract public function toHTMLString(): string;
 
   final public function __toString(): string {

--- a/src/html/element.hack
+++ b/src/html/element.hack
@@ -167,7 +167,7 @@ abstract xhp class element extends x\primitive {
         if ($val === true) {
           $buf .= ' '.\htmlspecialchars($key);
         } else {
-          if ($val is \Facebook\XHP\UnsafeAttributeValue) {
+          if ($val is \Facebook\XHP\UnsafeAttributeValue_DEPRECATED) {
             $val_str = $val->toHTMLString();
           } else {
             $val_str = \htmlspecialchars((string)$val, \ENT_COMPAT);

--- a/tests/UnsafeInterfacesTest.hack
+++ b/tests/UnsafeInterfacesTest.hack
@@ -28,7 +28,7 @@ class ExampleVeryUnsafeRenderable
   implements Facebook\XHP\UnsafeRenderable, Facebook\XHP\AlwaysValidChild {
 }
 
-class ExampleUnsafeAttribute extends Facebook\XHP\UnsafeAttributeValue {
+class ExampleUnsafeAttribute extends Facebook\XHP\UnsafeAttributeValue_DEPRECATED {
   public function __construct(public string $htmlString) {
   }
 
@@ -64,14 +64,14 @@ class UnsafeInterfacesTest extends Facebook\HackTest\HackTest {
   }
 
   public async function testUnsafeAttribute(): Awaitable<void> {
-    // without using XHPUnsafeAttributeValue, each &amp; will be double-escaped as &amp;amp;
+    // without using XHPUnsafeAttributeValue_DEPRECATED, each &amp; will be double-escaped as &amp;amp;
     $attr = 'foo &amp;&amp; bar';
     $xhp = <div onclick={$attr} />;
     expect(await $xhp->toStringAsync())->toEqual(
       '<div onclick="foo &amp;amp;&amp;amp; bar"></div>',
     );
 
-    // using XHPUnsafeAttributeValue the &amp; is not double escaped
+    // using XHPUnsafeAttributeValue_DEPRECATED the &amp; is not double escaped
     $escaped = new ExampleUnsafeAttribute('foo &amp;&amp; bar');
     $xhp = <div />;
     $xhp->forceAttribute('onclick', $escaped);


### PR DESCRIPTION
This is almost the same as a unsafe type fixme, except that it also
bypasses runtime enforcement. It will need to be removed before the type
system can be sound.
