### PR TITLE
Clean up dependencies of xhp-lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": ["MIT"],
     "require": {
         "hhvm": "^4.73",
-        "hhvm/type-assert": "^3.0|^4.0"
+        "hhvm/hsl": "^4.36.0"
     },
     "require-dev": {
         "facebook/fbexpect": "^2.0.0",


### PR DESCRIPTION
This composer.json did not mention that we depended on the hsl.
The hsl came for free with type-assert.
We don't need TypeAssert, since we don't depend on varrayness.
This also improves perf, since we are not spinning in
a loop validating that all elements are mixed, which they always are.