### PR TITLE
Update incorrect docblock for isAttributeSet

### DIFF
--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -431,8 +431,8 @@ abstract xhp class node implements \XHPChild {
   /**
    * Whether the attribute has been explicitly set in either the XhpOpenTag
    * or using setAttribute(). An attribute with a default value is not
-   * automatically considered set. Explicitly setting a value which is the
-   * same as the default value will make this method return true for that attribute.
+   * automatically considered set. Explicitly setting a value, which may be
+   * the same as the default value, will cause this method to return true.
    *
    * @param $attr attribute to check
    */

--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -177,7 +177,6 @@ abstract xhp class node implements \XHPChild {
     return $children;
   }
 
-
   /**
    * Fetches the first direct child of the element, if any.
    */

--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -429,8 +429,10 @@ abstract xhp class node implements \XHPChild {
   }
 
   /**
-   * Whether the attribute has been explicitly set to a nonnull value by the
-   * caller (vs. using the default set by "attribute" in the class definition).
+   * Whether the attribute has been explicitly set in either the XhpOpenTag
+   * or using setAttribute(). An attribute with a default value is not
+   * automatically considered set. Explicitly setting a value which is the
+   * same as the default value will make this method return true for that attribute.
    *
    * @param $attr attribute to check
    */

--- a/src/exceptions/InvalidChildrenException.hack
+++ b/src/exceptions/InvalidChildrenException.hack
@@ -7,7 +7,6 @@
  *
  */
 
-
 namespace Facebook\XHP;
 
 use namespace Facebook\XHP\Core as x;

--- a/src/html/tags/c/ConditionalComment.hack
+++ b/src/html/tags/c/ConditionalComment.hack
@@ -9,7 +9,6 @@
 
 namespace Facebook\XHP\HTML;
 
-
 use namespace Facebook\XHP\{ChildValidation as XHPChild, Core as x};
 use namespace HH\Lib\{Str, Vec};
 
@@ -26,7 +25,6 @@ final xhp class conditional_comment extends x\primitive {
       XHPChild\any_of(XHPChild\pcdata(), XHPChild\of_type<x\node>()),
     );
   }
-
 
   <<__Override>>
   protected async function stringifyAsync(): Awaitable<string> {

--- a/src/html/tags/d/Doctype.hack
+++ b/src/html/tags/d/Doctype.hack
@@ -23,7 +23,6 @@ final xhp class doctype extends x\primitive {
     return XHPChild\of_type<html>();
   }
 
-
   <<__Override>>
   protected async function stringifyAsync(): Awaitable<string> {
     return '<!DOCTYPE html>'.

--- a/tests/ChildRuleTest.hack
+++ b/tests/ChildRuleTest.hack
@@ -49,7 +49,6 @@ xhp class test:old_child_declaration_only extends x\element {
     return XHPChild\of_type<div>();
   }
 
-
   <<__Override>>
   protected async function renderAsync(): Awaitable<x\node> {
     return <x:frag>{$this->getChildren()}</x:frag>;
@@ -156,7 +155,6 @@ xhp class test:three_children extends x\element {
   }
 }
 
-
 xhp class test:either_of_two_children extends x\element {
   use XHPChild\Validation;
   protected static function getChildrenDeclaration(): XHPChild\Constraint {
@@ -184,7 +182,6 @@ xhp class test:any_of_three_children extends x\element {
     return <div />;
   }
 }
-
 
 xhp class test:nested_rule extends x\element {
   use XHPChild\Validation;


### PR DESCRIPTION
This docblock mentions was incorrect, because an explicit null would make this method return true.