### PR TITLE
Add nonce attribute to <script>

### DIFF
--- a/src/html/tags/s/Script.hack
+++ b/src/html/tags/s/Script.hack
@@ -21,6 +21,7 @@ final xhp class script
     enum {'anonymous', 'use-credentials'} crossorigin,
     bool defer,
     bool nomodule,
+    string nonce,
     enum {
       '',
       'no-referrer',


### PR DESCRIPTION
This is part of the HTML5 spec but missing from xhp-lib
per https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script