### PR TITLE
v3.x ubuntu targetting

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,12 +11,18 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu ]
+        os: [ ubuntu-latest ]
         hhvm:
           - '4.32'
           - latest
           - nightly
-    runs-on: ${{matrix.os}}-latest
+        include:
+          - hhvm: '4.32'
+            os: ubuntu-18.04
+        exclude:
+          - hhvm: '4.32'
+            os: ubuntu-latest
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - name: Create branch for version alias


### PR DESCRIPTION
- update branch alias
- Support TypeAssert v4
- fix another varray/darray confusion
- try bumping minimum version to 4.32 (oldest supported release)
- add fixme whitelists to hopefully fix CI
- also permit 4107 fixme
- fix Set->toArray() call
- array -> varray typehint
- replace is_array() calls
- add missing HH_FIXME for HHVM 4.32
- add namespace-related flags
- Remove assert calls refine local instead of array index
- Replace travis with github
- specify demangle options for running autoloader and tests
- add missing FIXME codes
- use shared github action
- Fix :xhp::__construct $children type
- Target old ubuntu 18.04 for HHVM 4.32 CI
