### PR TITLE
Repair xhp-lib@v3 on newer hhvm versions

### DIFF
--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -614,7 +614,7 @@ abstract class :x:composable-element extends :xhp {
     }
   }
 
-  final private function validateChildrenExpression(
+  private function validateChildrenExpression(
     ReflectionXHPChildrenExpression $expr,
     int $index,
   ): (bool, int) {
@@ -685,7 +685,7 @@ abstract class :x:composable-element extends :xhp {
     }
   }
 
-  final private function validateChildrenRule(
+  private function validateChildrenRule(
     ReflectionXHPChildrenExpression $expr,
     int $index,
   ): (bool, int) {

--- a/src/core/Primitive.php
+++ b/src/core/Primitive.php
@@ -26,7 +26,7 @@ abstract class :x:primitive extends :x:composable-element implements XHPRoot {
     return $that->stringify();
   }
 
-  final private async function __flushElementChildren(): Awaitable<void> {
+  private async function __flushElementChildren(): Awaitable<void> {
     $children = $this->getChildren();
     $awaitables = Map {};
     foreach ($children as $idx => $child) {

--- a/src/core/XHPAttributeCoercion.php
+++ b/src/core/XHPAttributeCoercion.php
@@ -72,7 +72,11 @@ abstract final class XHPAttributeCoercion {
       return (string)$val;
     }
     if ($val is Stringish) {
-      return /* HH_FIXME[4128] */ $val->__toString();
+      /* HH_FIXME[4053] HH_FIXME[4062] HH_FIXME[4128]
+         We know that $val is (not string & Stringish).
+         This implies StringishObject, so calling __toString() is safe.
+         StringishObject was added in hhvm 4.118 and this branch targets 4.32+. */
+      return $val->__toString();
     }
 
     throw new XHPInvalidAttributeException($context, 'string', $attr, $val);

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -94,7 +94,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testShapeWithExtraKey(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
     expect(() ==> {
 
       $x =
@@ -107,7 +109,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testShapeWithMissingOptionalKey(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
     expect(() ==> {
 
       /* HH_IGNORE_ERROR[4057] */
@@ -117,7 +121,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testShapeWithMissingRequiredKey(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
     expect(() ==> {
       /* HH_IGNORE_ERROR[4057] */
       $x = <test:attribute-types myshape={shape()} />;
@@ -132,7 +138,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testInvalidArrayKeys(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -150,7 +158,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testInvalidNum(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
 
     expect(() ==> {
       $x =
@@ -332,7 +342,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testNotAContainerAsArray(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -344,7 +356,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testHackContainerAsArray(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -354,7 +368,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testIncompatibleObjectAsObject(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -366,7 +382,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testPassingArrayAsVector(): void {
-    self::markTestSkipped('Only enums are validated at runtime.');
+    (): void ==> {
+      self::markTestSkipped('Only enums are validated at runtime.');
+    }();
     expect(() ==> {
       $x =
         <test:attribute-types
@@ -433,7 +451,9 @@ class AttributesTest extends Facebook\HackTest\HackTest {
   }
 
   public function testRenderCallableAttribute(): void {
-    self::markTestSkipped('This type has been unsupported since 2.0');
+    (): void ==> {
+      self::markTestSkipped('This type has been unsupported since 2.0');
+    }();
     expect(() ==> {
       $x =
         <test:callable-attribute


### PR DESCRIPTION
The code still passes all the tests on the newest runtime.
The changes below make it pass the typechecker again.

 - Remove private on final methods.
 - Add more fixme's for calling __toString() on StringishObject.
 - Wrap noreturn functions into void wrappers, because coeffect
   tracking does not work in unreachable code.