### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 tests/ export-ignore
+.hhvmconfig.hdf export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "homepage": "https://github.com/facebook/xhp-lib",
     "license": ["MIT"],
     "require": {
-        "hhvm": "^4.102",
-        "hhvm/hsl": "^4.36.0"
+        "hhvm": "^4.128"
     },
     "require-dev": {
         "facebook/fbexpect": "^2.0.0",

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -5,5 +5,6 @@
   "devRoots": [
     "tests/"
   ],
-  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+  "useFactsIfAvailable": true
 }

--- a/src/Reflection/ReflectionXHPAttribute.hack
+++ b/src/Reflection/ReflectionXHPAttribute.hack
@@ -35,7 +35,7 @@ class ReflectionXHPAttribute {
 
   private static keyset<string> $specialAttributes = keyset['data', 'aria'];
 
-  public function __construct(private string $name, varray<mixed> $decl) {
+  public function __construct(private string $name, vec<mixed> $decl) {
     $this->type = XHPAttributeType::assert($decl[0]);
     $this->extraType = $decl[1];
     $this->defaultValue = $decl[2];

--- a/src/core/Node.hack
+++ b/src/core/Node.hack
@@ -576,20 +576,20 @@ abstract xhp class node implements \XHPChild {
    * Attribute types are suggested by the TYPE_* constants.
    */
   protected static function __xhpAttributeDeclaration(
-  ): darray<string, varray<mixed>> {
-    return darray[];
+  ): dict<string, vec<mixed>> {
+    return dict[];
   }
 
   /**
    * Defined in elements by the `category` keyword. This is just a list of all
    * categories an element belongs to. Each category is a key with value 1.
    */
-  protected function __xhpCategoryDeclaration(): darray<string, int> {
+  protected function __xhpCategoryDeclaration(): dict<string, int> {
     return self::__NO_LEGACY_CATEGORY_DECLARATION;
   }
 
   const int __NO_LEGACY_CHILDREN_DECLARATION = -31337;
-  const darray<string, int> __NO_LEGACY_CATEGORY_DECLARATION = darray["\0INVALID\0" => 0];
+  const dict<string, int> __NO_LEGACY_CATEGORY_DECLARATION = dict["\0INVALID\0" => 0];
 
   /**
    * Defined in elements by the `children` keyword. This returns a pattern of
@@ -775,7 +775,7 @@ abstract xhp class node implements \XHPChild {
    * :span[%inline],pcdata
    */
   final public function __getChildrenDescription(): string {
-    $desc = varray[];
+    $desc = vec[];
     foreach ($this->children as $child) {
       if ($child is node) {
         $tmp = '\\'.\get_class($child);
@@ -801,7 +801,7 @@ abstract xhp class node implements \XHPChild {
       return true;
     }
     // XHP parses the category string
-    $c = \str_replace(varray[':', '-'], varray['__', '_'], $c);
+    $c = \str_replace(vec[':', '-'], vec['__', '_'], $c);
     return ($categories[$c] ?? null) !== null;
   }
 

--- a/tests/AsyncTest.hack
+++ b/tests/AsyncTest.hack
@@ -106,7 +106,7 @@ class AsyncTest extends Facebook\HackTest\HackTest {
     $b = <async:par_test label="b" />;
     $c = <async:par_test label="c" />;
 
-    $container->replaceChildren(varray[$b, $c]);
+    $container->replaceChildren(vec[$b, $c]);
 
     $tree = <async:test>{$a}{$container}</async:test>;
     expect(await $tree->toStringAsync())->toEqual(

--- a/tests/AttributesTest.hack
+++ b/tests/AttributesTest.hack
@@ -18,7 +18,7 @@ xhp class test:attribute_types extends x\element {
     string mystring,
     bool mybool,
     int myint,
-    varray<int> myarray,
+    vec<int> myarray,
     stdClass myobject,
     enum {'foo', 'bar'} myenum,
     float myfloat,
@@ -78,7 +78,7 @@ class AttributesTest extends Facebook\HackTest\HackTest {
         mystring="foo"
         mybool={true}
         myint={123}
-        myarray={varray[1, 2, 3]}
+        myarray={vec[1, 2, 3]}
         myobject={new stdClass()}
         myenum={'foo'}
         myfloat={1.23}


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.
All legacy arrays have been replaced with Hack arrays.